### PR TITLE
Fixing issue with using GlyphIds in text operators

### DIFF
--- a/src/AbstractContentContextDriver.cpp
+++ b/src/AbstractContentContextDriver.cpp
@@ -1661,6 +1661,8 @@ GlyphUnicodeMappingList AbstractContentContextDriver::ArrayToGlyphsList(const v8
         mapping.mGlyphCode = arrayObject->Get(i)->ToObject()->Get(0)->ToNumber()->Uint32Value();
         for(int j=1; j < itemLength;++j)
             mapping.mUnicodeValues.push_back(arrayObject->Get(i)->ToObject()->Get(j)->ToNumber()->Uint32Value());
+			
+		glyphList.push_back(mapping);
     }
    
     return glyphList;

--- a/tests/SimpleTextUsageTest.js
+++ b/tests/SimpleTextUsageTest.js
@@ -73,5 +73,22 @@ var hummus = require('../hummus');
     pdfWriter.writePage(page)
             .end();
 }
+// this one adds text using the GlyphIds
+{
+    var pdfWriter = hummus.createWriter('./output/SimpleTextUsageGlyphs.pdf');
+    
+    var page = pdfWriter.createPage(0,0,595,842);
+    
+    var font = pdfWriter.getFontForFile('./TestMaterials/fonts/arial.ttf');
+    pdfWriter.startPageContentContext(page).BT()
+                                        .k(0,0,0,1)
+                                        .Tf(font,1)
+                                        .Tm(30,0,0,30,78.4252,662.8997)
+                                        .Tj([[68,97],[69,98],[70,99],[71,100]])
+                                        .ET();
+    pdfWriter.writePage(page)
+            .end();
+}
+
 
 console.log('done - ok');


### PR DESCRIPTION
Hi Gal
Came across this issue when using Glyph Ids. Does the fix make sense to you? 

...........
e.g Tj was using ArrayToGlyphsList which wasn't adding the Glyphs map to
the glyphList
Added test for this scenario
