### PR TITLE
Optionally accept stream instead of filepath in MergePDFPagesToPage

### DIFF
--- a/hummus.js
+++ b/hummus.js
@@ -147,7 +147,7 @@ PDFRStreamForFile.prototype.skip = function(inAmount)
     this.rposition += inAmount;
 }
 
-PDFRStreamForFile.prototype.getCurrentPosition = function(inAmount)
+PDFRStreamForFile.prototype.getCurrentPosition = function()
 {
     return this.rposition;
 }

--- a/src/PDFWriterDriver.cpp
+++ b/src/PDFWriterDriver.cpp
@@ -940,19 +940,27 @@ METHOD_RETURN_TYPE PDFWriterDriver::MergePDFPagesToPage(const ARGS_TYPE& args)
     /*
         parameters are:
             target page
-            file path to pdf to merge pages to
+            file path to pdf to merge pages from OR stream of pdf to merge pages from
             optional 1: options object
             optional 2: callback function to call after each page merge
      */
     
-    if(args.Length() < 2 ||
-       !PDFPageDriver::HasInstance(args[0]) ||
-       !(args[1]->IsString() || 
-         (args[1]->IsObject() && 
-          IByteReaderWithPosition::HasInstance(args[1])))
-      )
+    if(args.Length() < 2)
     {
-		THROW_EXCEPTION("Wrong arguments, pass a page object, a path to pages source file or an IByteReaderWithPosition, and two optional: configuration object and callback function that will be called between pages merging");
+		THROW_EXCEPTION("Too few arguments. Pass a page object, a path to pages source file or an IByteReaderWithPosition, and two optional: configuration object and callback function that will be called between pages merging");
+		SET_FUNCTION_RETURN_VALUE(UNDEFINED);
+    }
+    
+    if(!PDFPageDriver::HasInstance(args[0]))
+    {
+		THROW_EXCEPTION("Invalid arguments. First argument must be a page object");
+		SET_FUNCTION_RETURN_VALUE(UNDEFINED);        
+    }
+    
+    if(!args[1]->IsString() && 
+       !IByteReaderWithPosition::HasInstance(args[1]))
+    {
+		THROW_EXCEPTION("Invalid arguments. Second argument must be either an input stream or a path to a pages source file.");
 		SET_FUNCTION_RETURN_VALUE(UNDEFINED);
     }
     

--- a/src/PDFWriterDriver.cpp
+++ b/src/PDFWriterDriver.cpp
@@ -19,6 +19,7 @@
  */
 #include "PDFWriterDriver.h"
 #include "PDFPageDriver.h"
+#include "ByteReaderWithPositionDriver.h"
 #include "PageContentContextDriver.h"
 #include "FormXObjectDriver.h"
 #include "UsedFontDriver.h"
@@ -958,7 +959,7 @@ METHOD_RETURN_TYPE PDFWriterDriver::MergePDFPagesToPage(const ARGS_TYPE& args)
     }
     
     if(!args[1]->IsString() && 
-       !IByteReaderWithPosition::HasInstance(args[1]))
+       !ByteReaderWithPositionDriver::HasInstance(args[1]))
     {
 		THROW_EXCEPTION("Invalid arguments. Second argument must be either an input stream or a path to a pages source file.");
 		SET_FUNCTION_RETURN_VALUE(UNDEFINED);
@@ -992,9 +993,9 @@ METHOD_RETURN_TYPE PDFWriterDriver::MergePDFPagesToPage(const ARGS_TYPE& args)
     }
     else 
     {
-        IByteReaderWithPosition* byteReader = ObjectWrap::Unwrap<IByteReaderWithPosition>(args[1]->ToObject());
+        ByteReaderWithPositionDriver* byteReader = ObjectWrap::Unwrap<ByteReaderWithPositionDriver>(args[1]->ToObject());
         status = pdfWriter->mPDFWriter.MergePDFPagesToPage(page->GetPage(),
-                                                           byteReader,
+                                                           byteReader->GetStream(),
                                                            pageRange);
     }
 	

--- a/src/PDFWriterDriver.cpp
+++ b/src/PDFWriterDriver.cpp
@@ -959,7 +959,7 @@ METHOD_RETURN_TYPE PDFWriterDriver::MergePDFPagesToPage(const ARGS_TYPE& args)
     }
     
     if(!args[1]->IsString() && 
-       !ByteReaderWithPositionDriver::HasInstance(args[1]))
+       !args[1]->IsObject())
     {
 		THROW_EXCEPTION("Invalid arguments. Second argument must be either an input stream or a path to a pages source file.");
 		SET_FUNCTION_RETURN_VALUE(UNDEFINED);
@@ -993,9 +993,9 @@ METHOD_RETURN_TYPE PDFWriterDriver::MergePDFPagesToPage(const ARGS_TYPE& args)
     }
     else 
     {
-        ByteReaderWithPositionDriver* byteReader = ObjectWrap::Unwrap<ByteReaderWithPositionDriver>(args[1]->ToObject());
+        ObjectByteReaderWithPosition* proxy = new ObjectByteReaderWithPosition(args[1]->ToObject());
         status = pdfWriter->mPDFWriter.MergePDFPagesToPage(page->GetPage(),
-                                                           byteReader->GetStream(),
+                                                           proxy,
                                                            pageRange);
     }
 	

--- a/tests/MergePDFPages.js
+++ b/tests/MergePDFPages.js
@@ -172,7 +172,7 @@ describe('MergePDFPages', function() {
 		});
 	});
 		
-	describe('OnlyMergeFromStream', function() {
+	describe('MergeFromStream', function() {
 		it('should complete without error', function() {
 			var pdfWriter = hummus.createWriter(__dirname + '/output/TestOnlyMerge.pdf');
 			var page = pdfWriter.createPage(0,0,595,842);

--- a/tests/MergePDFPages.js
+++ b/tests/MergePDFPages.js
@@ -171,4 +171,21 @@ describe('MergePDFPages', function() {
 			pdfWriter.writePage(page).end();
 		});
 	});
+	
+	
+	
+	describe('OnlyMergeFromStream', function() {
+		it('should complete without error', function() {
+			var pdfWriter = hummus.createWriter(__dirname + '/output/TestOnlyMerge.pdf');
+			var page = pdfWriter.createPage(0,0,595,842);
+			
+			var inStream = new hummus.PDFRStreamForFile(__dirname + '/TestMaterials/AddedPage.pdf');
+
+			pdfWriter.mergePDFPagesToPage(page,
+				inStream,
+				{type:hummus.eRangeTypeSpecific,specificRanges:[[0,0]]})
+
+			pdfWriter.writePage(page).end();
+		});
+	});
 });

--- a/tests/MergePDFPages.js
+++ b/tests/MergePDFPages.js
@@ -171,9 +171,7 @@ describe('MergePDFPages', function() {
 			pdfWriter.writePage(page).end();
 		});
 	});
-	
-	
-	
+		
 	describe('OnlyMergeFromStream', function() {
 		it('should complete without error', function() {
 			var pdfWriter = hummus.createWriter(__dirname + '/output/TestOnlyMerge.pdf');

--- a/tests/MergePDFPages.js
+++ b/tests/MergePDFPages.js
@@ -174,7 +174,7 @@ describe('MergePDFPages', function() {
 		
 	describe('MergeFromStream', function() {
 		it('should complete without error', function() {
-			var pdfWriter = hummus.createWriter(__dirname + '/output/TestOnlyMerge.pdf');
+			var pdfWriter = hummus.createWriter(__dirname + '/output/TestStreamMerge.pdf');
 			var page = pdfWriter.createPage(0,0,595,842);
 			
 			var inStream = new hummus.PDFRStreamForFile(__dirname + '/TestMaterials/AddedPage.pdf');


### PR DESCRIPTION
The underlying PDFWriter already accepts an IByteReaderWithPosition but the driver didn't allow it. This updates the input validation to allow a stream to be passed in and calls the correct PDFWriter.MergePDFPagesToPage method depending on which type of argument is passed.

Note this is a fix from the previous pull request. This one builds and passes all tests. I've validated output working with the provided PDFRStreamForFile from the hummus.js file as well as through a custom stream. 