### PR TITLE
Update Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,18 @@
 Hummus JS is a PDF generation and parsing module.
 It is implemented as a NodeJS driver to the PDFHummus library.
 
+### Install Dependencies
+Install hummus' dependencies by using this command
+```
+npm install -g node-pre-gyp
+```
+
+### Install Hummus.js
+Next install the hummus.js library
+```
+npm install hummus
+```
+That's all!
 
 Check out the [wiki pages for documentation](https://github.com/galkahana/HummusJS/wiki).
 
@@ -12,3 +24,4 @@ For announcements and examples, visit the HummusJS and PDFHummus blog at http://
 
 visit the Hummus JS git project in https://github.com/galkahana/HummusJS
 visit the PDFHummus git project in https://github.com/galkahana/pdf-writer
+


### PR DESCRIPTION
node-pre-gyp is a global dependency. 

Without it, the ```npm install hummus``` fails silently.

```npm install hummus``` => output
```
> hummus@1.0.60 install /home/san-teong-ezcrm/node_modules/hummus
> node-pre-gyp install --fallback-to-build
```

When requiring the script, error output 
```
module.js:340
    throw err;
    ^
Error: Cannot find module '/home/san-teong-ezcrm/node_modules/hummus/binding/hummus.node'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:280:25)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Object.<anonymous> (/home/san-teong-ezcrm/node_modules/hummus/hummus.js:5:31)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Object.<anonymous> (/home/san-teong-ezcrm/components/pdf/PdfModifier.js:2:14)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
error: Forever detected script exited with code: 8
```