### PR TITLE
Objects parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ tests/output
 binding
 node_modules
 aws.json
+etc
 
 #all the binaries
 # Compiled source #

--- a/binding.gyp
+++ b/binding.gyp
@@ -56,6 +56,7 @@
                 './src/ObjectByteReaderWithPosition.cpp',
                 './src/ObjectByteWriter.cpp',
                 './src/ObjectByteWriterWithPosition.cpp',
+                './src/PDFObjectParserDriver.cpp',
                 './src/hummus.cpp'
             ]
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hummus",
-  "version": "1.0.68",
+  "version": "1.0.69",
   "description": "Create, read and modify PDF files and streams",
   "homepage": "http://pdfhummus.com/",
   "license": "Apache-2.0",

--- a/src/PDFObjectParserDriver.cpp
+++ b/src/PDFObjectParserDriver.cpp
@@ -1,4 +1,4 @@
-#include "PDFObjectPArserDriver.h"
+#include "PDFObjectParserDriver.h"
 #include "PDFObjectParser.h"
 #include "PDFObjectDriver.h"
 #include "RefCountPtr.h"

--- a/src/PDFObjectParserDriver.cpp
+++ b/src/PDFObjectParserDriver.cpp
@@ -1,0 +1,79 @@
+#include "PDFObjectPArserDriver.h"
+#include "PDFObjectParser.h"
+#include "PDFObjectDriver.h"
+#include "RefCountPtr.h"
+#include "PDFObject.h"
+
+using namespace v8;
+
+Persistent<Function> PDFObjectParserDriver::constructor;
+Persistent<FunctionTemplate> PDFObjectParserDriver::constructor_template;
+
+PDFObjectParserDriver::PDFObjectParserDriver()
+{
+    PDFObjectParserInstance = NULL;
+}
+
+void PDFObjectParserDriver::Init()
+{
+	CREATE_ISOLATE_CONTEXT;
+
+	Local<FunctionTemplate> t = NEW_FUNCTION_TEMPLATE(New);
+
+	t->SetClassName(NEW_STRING("PDFObjectParserDriver"));
+	t->InstanceTemplate()->SetInternalFieldCount(1);
+
+	SET_PROTOTYPE_METHOD(t, "parseNewObject", ParseNewObject);
+	SET_CONSTRUCTOR(constructor,t);
+	SET_CONSTRUCTOR_TEMPLATE(constructor_template,t);
+}
+
+METHOD_RETURN_TYPE PDFObjectParserDriver::NewInstance(const ARGS_TYPE& args)
+{
+	CREATE_ISOLATE_CONTEXT;
+	CREATE_ESCAPABLE_SCOPE;
+	
+	Local<Object> instance = NEW_INSTANCE(constructor);
+	SET_FUNCTION_RETURN_VALUE(instance);
+}
+
+v8::Handle<v8::Value> PDFObjectParserDriver::GetNewInstance(const ARGS_TYPE& args)
+{
+	CREATE_ISOLATE_CONTEXT;
+	CREATE_ESCAPABLE_SCOPE;
+
+	Local<Object> instance = NEW_INSTANCE(constructor);
+	return CLOSE_SCOPE(instance);
+}
+
+bool PDFObjectParserDriver::HasInstance(Handle<Value> inObject)
+{
+	CREATE_ISOLATE_CONTEXT;
+	
+	return inObject->IsObject() && HAS_INSTANCE(constructor_template, inObject);
+}
+
+METHOD_RETURN_TYPE PDFObjectParserDriver::New(const ARGS_TYPE& args)
+{
+	CREATE_ISOLATE_CONTEXT;
+	CREATE_ESCAPABLE_SCOPE;
+
+    PDFObjectParserDriver* driver = new PDFObjectParserDriver();
+    driver->Wrap(args.This());
+	SET_FUNCTION_RETURN_VALUE(args.This());
+}
+
+METHOD_RETURN_TYPE PDFObjectParserDriver::ParseNewObject(const ARGS_TYPE& args)
+{
+    CREATE_ISOLATE_CONTEXT;
+	CREATE_ESCAPABLE_SCOPE;
+
+    PDFObjectParserDriver* self = ObjectWrap::Unwrap<PDFObjectParserDriver>(args.This());
+    
+    RefCountPtr<PDFObject> newObject = self->PDFObjectParserInstance->ParseNewObject();
+    
+    if(!newObject)
+        SET_FUNCTION_RETURN_VALUE(UNDEFINED);
+    else
+        SET_FUNCTION_RETURN_VALUE(PDFObjectDriver::CreateDriver(newObject.GetPtr()));
+}

--- a/src/PDFObjectParserDriver.h
+++ b/src/PDFObjectParserDriver.h
@@ -1,0 +1,47 @@
+/*
+ Source File : PDFReaderDriver
+ 
+ 
+ Copyright 2013 Gal Kahana HummusJS
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ 
+ */
+#pragma once
+
+#include "nodes.h"
+
+class PDFObjectParser;
+
+class PDFObjectParserDriver : public node::ObjectWrap
+{
+public:
+    static void Init();
+	static METHOD_RETURN_TYPE NewInstance(const ARGS_TYPE& args);
+	static v8::Handle<v8::Value> GetNewInstance(const ARGS_TYPE& args);
+    static bool HasInstance(v8::Handle<v8::Value> inObject);
+    
+    
+    
+    PDFObjectParser* PDFObjectParserInstance;
+    
+private:
+    PDFObjectParserDriver();
+    
+    
+    static v8::Persistent<v8::Function> constructor;
+    static v8::Persistent<v8::FunctionTemplate> constructor_template;
+	
+	static METHOD_RETURN_TYPE New(const ARGS_TYPE& args);
+	static METHOD_RETURN_TYPE ParseNewObject(const ARGS_TYPE& args);
+};

--- a/src/PDFReaderDriver.h
+++ b/src/PDFReaderDriver.h
@@ -62,8 +62,11 @@ private:
 	static METHOD_RETURN_TYPE GetXrefSize(const ARGS_TYPE& args);
 	static METHOD_RETURN_TYPE GetXrefEntry(const ARGS_TYPE& args);
 	static METHOD_RETURN_TYPE GetXrefPosition(const ARGS_TYPE& args);
+	static METHOD_RETURN_TYPE GetParserStream(const ARGS_TYPE& args);
 	static METHOD_RETURN_TYPE StartReadingFromStream(const ARGS_TYPE& args);
-	static METHOD_RETURN_TYPE  GetParserStream(const ARGS_TYPE& args);
+	static METHOD_RETURN_TYPE StartReadingFromStreamForPlainCopying(const ARGS_TYPE& args);
+	static METHOD_RETURN_TYPE StartReadingObjectsFromStream(const ARGS_TYPE& args);
+	
 
     
     bool mStartedWithStream;

--- a/src/deps/PDFWriter/PDFObjectParser.cpp
+++ b/src/deps/PDFWriter/PDFObjectParser.cpp
@@ -53,12 +53,20 @@ PDFObjectParser::PDFObjectParser(void)
 
 PDFObjectParser::~PDFObjectParser(void)
 {
+	if(mOwnsStream)
+		delete mStream;
 }
 
 void PDFObjectParser::SetReadStream(IByteReader* inSourceStream,
-									IReadPositionProvider* inCurrentPositionProvider)
+									IReadPositionProvider* inCurrentPositionProvider,
+									bool inOwnsStream)
 {
+	if(mOwnsStream) {
+		delete mStream;
+	}
+
 	mStream = inSourceStream;
+	mOwnsStream = inOwnsStream;
 	mTokenizer.SetReadStream(inSourceStream);
 	mCurrentPositionProvider = inCurrentPositionProvider;
 	ResetReadState();

--- a/src/deps/PDFWriter/PDFObjectParser.cpp
+++ b/src/deps/PDFWriter/PDFObjectParser.cpp
@@ -49,6 +49,8 @@ PDFObjectParser::PDFObjectParser(void)
 {
 	mParserExtender = NULL;
 	mDecryptionHelper = NULL;
+	mOwnsStream = false;
+	mStream = NULL;
 }
 
 PDFObjectParser::~PDFObjectParser(void)

--- a/src/deps/PDFWriter/PDFObjectParser.h
+++ b/src/deps/PDFWriter/PDFObjectParser.h
@@ -46,8 +46,8 @@ public:
 	~PDFObjectParser(void);
 
 	
-	// Assign the stream to read from (does not take ownership of the stream)
-	void SetReadStream(IByteReader* inSourceStream,IReadPositionProvider* inCurrentPositionProvider);
+	// Assign the stream to read from (does not take ownership of the stream, unless told so)
+	void SetReadStream(IByteReader* inSourceStream,IReadPositionProvider* inCurrentPositionProvider,bool inOwnsStream=false);
 
 	PDFObject* ParseNewObject();
 
@@ -71,6 +71,7 @@ private:
 	IReadPositionProvider* mCurrentPositionProvider;
 	IPDFParserExtender* mParserExtender;
 	DecryptionHelper* mDecryptionHelper;
+	bool mOwnsStream;
 
 	bool GetNextToken(std::string& outToken);
 	void SaveTokenToBuffer(std::string& inToken);

--- a/src/deps/PDFWriter/PDFParser.cpp
+++ b/src/deps/PDFWriter/PDFParser.cpp
@@ -2020,6 +2020,20 @@ IByteReader* PDFParser::StartReadingFromStream(PDFStreamInput* inStream)
     return result;
 }
 
+PDFObjectParser* PDFParser::StartReadingObjectsFromStream(PDFStreamInput* inStream) {
+	IByteReader* readStream = StartReadingFromStream(inStream);
+	if(!readStream)
+		return NULL;
+	
+	PDFObjectParser* objectsParser = new PDFObjectParser();
+	InputStreamSkipperStream* source = new InputStreamSkipperStream(readStream);
+	objectsParser->SetReadStream(source,source,true);
+	objectsParser->SetDecryptionHelper(&mDecryptionHelper);
+	objectsParser->SetParserExtender(mParserExtender);
+
+	return objectsParser;
+}
+
 IByteReader* PDFParser::CreateInputStreamReaderForPlainCopying(PDFStreamInput* inStream) {
 	RefCountPtr<PDFDictionary> streamDictionary(inStream->QueryStreamDictionary());
 	IByteReader* result = NULL;

--- a/src/deps/PDFWriter/PDFParser.h
+++ b/src/deps/PDFWriter/PDFParser.h
@@ -133,6 +133,11 @@ public:
     // delete the result when done
     IByteReader* StartReadingFromStream(PDFStreamInput* inStream);
 
+	// creates a PDFObjectParser object that you can use for reading objects
+	// from the input stream. very userful for reading content streams for
+	// interpreting them
+	PDFObjectParser* StartReadingObjectsFromStream(PDFStreamInput* inStream);
+
 	/*
 		Same as above, but reading only decrypts, but does not defiler. ideal for copying
 	*/

--- a/src/hummus.cpp
+++ b/src/hummus.cpp
@@ -67,6 +67,7 @@
 #include "ByteWriterWithPositionDriver.h"
 #include "PDFWriter.h"
 #include "PDFPageModifierDriver.h"
+#include "PDFObjectParserDriver.h"
 
 using namespace v8;
 using namespace node;
@@ -563,6 +564,7 @@ void HummusInit(Handle<Object> exports) {
 	ByteReaderWithPositionDriver::Init();
 	ByteWriterWithPositionDriver::Init();
     PDFPageModifierDriver::Init(exports);
+    PDFObjectParserDriver::Init();
 
     
     // define methods


### PR DESCRIPTION
Exposing the objects parser to nodejs.
The ObjectsParser as is allows to intrepret objects  while iterating a stream. can be used to implement pdf interpreter.

More specifically this can be used to interpret content streams, something highly usable if you are looking for image usage, text extraction or anything else tied to content.