### PR TITLE
Implement getFontMetrics method on UsedText

### DIFF
--- a/src/UsedFontDriver.h
+++ b/src/UsedFontDriver.h
@@ -41,5 +41,6 @@ private:
     static v8::Persistent<v8::FunctionTemplate> constructor_template;
 	static METHOD_RETURN_TYPE New(const ARGS_TYPE& args);
 	static METHOD_RETURN_TYPE CalculateTextDimensions(const ARGS_TYPE& args);
+    static METHOD_RETURN_TYPE GetFontMetrics(const ARGS_TYPE& args);
 
 };


### PR DESCRIPTION
Hi,

This is hopefully only the first of several pull requests I'll be submitting to help add some missing features that we need specifically around text.  I don't fully understand the abstractions you're using behind, so I don't know if there are better ways to handle some of this, but this gives me a part of what I need.

I'm still having some issues where CalculateTextDimensions is giving me incorrect values for some fonts (not sure why yet), so I hope to track that down at some point, but this is a start.

I'm also going to need to be able to request kerning information about the fonts at some point, but one thing at a time.

Please let me know if there are things that I need to do so that you can merge this; I'd like to contribute back to the project rather than just maintaining a separate fork.

- Richard a.k.a taxilian
GradeCam 