### PR TITLE
add internal links option

### DIFF
--- a/src/deps/PDFWriter/DocumentContext.cpp
+++ b/src/deps/PDFWriter/DocumentContext.cpp
@@ -1933,6 +1933,13 @@ EStatusCodeAndObjectIDType DocumentContext::WriteAnnotationAndLinkForURL(const s
 		linkAnnotationContext->WriteKey(scF);
 		linkAnnotationContext->WriteIntegerValue(4);
 
+		// Dest
+		bool internalLink = (encodedResult.second.size() > 0 && encodedResult.second[0] == '#');
+		if (internalLink) {
+			linkAnnotationContext->WriteKey("Dest");
+			linkAnnotationContext->WriteNameValue(encodedResult.second.c_str()+1);
+		}
+
 		// BS
 		linkAnnotationContext->WriteKey(scBS);
 		DictionaryContext* borderStyleContext = mObjectsContext->StartDictionary();
@@ -1941,23 +1948,25 @@ EStatusCodeAndObjectIDType DocumentContext::WriteAnnotationAndLinkForURL(const s
 		borderStyleContext->WriteIntegerValue(0);
 		mObjectsContext->EndDictionary(borderStyleContext);
 
-		// A
-		linkAnnotationContext->WriteKey(scA);
-		DictionaryContext* actionContext = mObjectsContext->StartDictionary();
+		if (!internalLink) {
+			// A
+			linkAnnotationContext->WriteKey(scA);
+			DictionaryContext* actionContext = mObjectsContext->StartDictionary();
 
-		// Type
-		actionContext->WriteKey(scType);
-		actionContext->WriteNameValue(scAction);
+			// Type
+			actionContext->WriteKey(scType);
+			actionContext->WriteNameValue(scAction);
 
-		// S
-		actionContext->WriteKey(scS);
-		actionContext->WriteNameValue(scURI);
+			// S
+			actionContext->WriteKey(scS);
+			actionContext->WriteNameValue(scURI);
 
-		// URI
-		actionContext->WriteKey(scURI);
-		actionContext->WriteLiteralStringValue(encodedResult.second);
-		
-		mObjectsContext->EndDictionary(actionContext);
+			// URI
+			actionContext->WriteKey(scURI);
+			actionContext->WriteLiteralStringValue(encodedResult.second);
+			
+			mObjectsContext->EndDictionary(actionContext);
+		}
 
 		mObjectsContext->EndDictionary(linkAnnotationContext);
 		mObjectsContext->EndIndirectObject();


### PR DESCRIPTION
This adds an option to add internal links for attachURLLinktoCurrentPage;

The code makes a simple check. If the URL begins with '#' like:
    pageModifier.attachURLLinktoCurrentPage('#begin', 30, 15, 300, 40);

In this instance "/Dest" key would be added instead of an Action.