### PR TITLE
Method to enable CatalogUpdateRequired from js

### DIFF
--- a/src/PDFWriterDriver.cpp
+++ b/src/PDFWriterDriver.cpp
@@ -55,7 +55,7 @@ PDFWriterDriver::PDFWriterDriver()
     mWriteStreamProxy = NULL;
     mReadStreamProxy = NULL;
     mStartedWithStream = false;
-    
+    mIsCatalogUpdateRequired = false;
 }
 
 PDFWriterDriver::~PDFWriterDriver()
@@ -105,6 +105,7 @@ void PDFWriterDriver::Init(Handle<Object> inExports)
 	SET_PROTOTYPE_METHOD(t, "getModifiedInputFile", GetModifiedInputFile);
 	SET_PROTOTYPE_METHOD(t, "getOutputFile", GetOutputFile);
 	SET_PROTOTYPE_METHOD(t, "registerAnnotationReferenceForNextPageWrite", RegisterAnnotationReferenceForNextPageWrite);
+    SET_PROTOTYPE_METHOD(t, "requireCatalogUpdate", RequireCatalogUpdate);    
 
 	SET_CONSTRUCTOR(constructor, t);
     SET_CONSTRUCTOR_EXPORT(inExports, "PDFWriter", t);
@@ -1481,6 +1482,18 @@ METHOD_RETURN_TYPE PDFWriterDriver::RegisterAnnotationReferenceForNextPageWrite(
     SET_FUNCTION_RETURN_VALUE(args.This());
 }
 
+METHOD_RETURN_TYPE PDFWriterDriver::RequireCatalogUpdate(const ARGS_TYPE& args)
+{
+    CREATE_ISOLATE_CONTEXT;
+    CREATE_ESCAPABLE_SCOPE;
+
+    PDFWriterDriver* pdfWriter = ObjectWrap::Unwrap<PDFWriterDriver>(args.This());
+
+    pdfWriter->mIsCatalogUpdateRequired = true;
+
+    SET_FUNCTION_RETURN_VALUE(UNDEFINED);
+}
+
 /*
     From now on, extensions event triggers.
     got the following events for now:
@@ -1674,7 +1687,7 @@ PDFHummus::EStatusCode PDFWriterDriver::OnPDFCopyingComplete(
 }
 bool PDFWriterDriver::IsCatalogUpdateRequiredForModifiedFile(PDFParser* inModifiderFileParser) {
     
-    return false;
+    return mIsCatalogUpdateRequired;
 }
 
 PDFHummus::EStatusCode PDFWriterDriver::setupListenerIfOK(PDFHummus::EStatusCode inCode) {

--- a/src/PDFWriterDriver.h
+++ b/src/PDFWriterDriver.h
@@ -219,6 +219,7 @@ private:
     static METHOD_RETURN_TYPE GetOutputFile(const ARGS_TYPE& args);
     static METHOD_RETURN_TYPE GetDocumentContext(const ARGS_TYPE& args);
     static METHOD_RETURN_TYPE RegisterAnnotationReferenceForNextPageWrite(const ARGS_TYPE& args);
+	static METHOD_RETURN_TYPE RequireCatalogUpdate(const ARGS_TYPE& args);
     
     static CMYKRGBColor colorFromArray(v8::Handle<v8::Value> inArray);
     static PDFPageRange ObjectToPageRange(v8::Handle<v8::Object> inObject);
@@ -227,6 +228,7 @@ private:
     PDFHummus::EStatusCode triggerEvent(const std::string& inEventName, v8::Handle<v8::Object> inParams);
     
     bool mStartedWithStream;
+	bool mIsCatalogUpdateRequired;    
     PDFWriter mPDFWriter;
     ObjectByteWriterWithPosition* mWriteStreamProxy;
     ObjectByteReaderWithPosition* mReadStreamProxy;


### PR DESCRIPTION
The Catalog Write Events is not fired if there is no changes on pdf. But the PdfWriter calls IsCatalogUpdateRequiredForModifiedFile from extender and we can force catalog update if we need. 

I'm using these event to create Metadata entry in pdf catalog instead of recreate entire object. 

Follows the usage example:

`          const objectId = objectsContext.startNewIndirectObject();
            pdfWriter.requireCatalogUpdate();
            pdfWriter.getEvents().on('OnCatalogWrite',function(dictionaryContext){
                dictionaryContext.catalogDictionaryContext.writeKey('Metadata');
                dictionaryContext.catalogDictionaryContext.writeObjectReferenceValue(objectId);
            });
`