### PR TITLE
Changed the buffer size from 10Mb to 1K

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "author": "Gal Kahana <gal.kahana@hotmail.com>",
   "main": "./hummus.js",
   "scripts": {
-    "install": "node-pre-gyp install --fallback-to-build",
+    "install": "node-pre-gyp install --build-from-source",
     "test": "mocha -R tap ./tests/*.js --timeout 15000"
   },
   "repository": {

--- a/src/deps/PDFWriter/OutputStreamTraits.cpp
+++ b/src/deps/PDFWriter/OutputStreamTraits.cpp
@@ -33,16 +33,16 @@ OutputStreamTraits::~OutputStreamTraits(void)
 {
 }
 
-#define TENMEGS 10*1024*1024
+#define ONEK 1024
 EStatusCode OutputStreamTraits::CopyToOutputStream(IByteReader* inInputStream)
 {
-	Byte* buffer = new Byte[TENMEGS];
+	Byte* buffer = new Byte[ONEK];
 	LongBufferSizeType readBytes,writeBytes;
 	EStatusCode status = PDFHummus::eSuccess;
 
 	while(inInputStream->NotEnded() && PDFHummus::eSuccess == status)
 	{
-		readBytes = inInputStream->Read(buffer,TENMEGS);
+		readBytes = inInputStream->Read(buffer,ONEK);
 		writeBytes = mOutputStream->Write(buffer,readBytes);
 		status = (readBytes == writeBytes) ? PDFHummus::eSuccess:PDFHummus::eFailure;
 		if (readBytes == 0) {


### PR DESCRIPTION
When using two streams as inputs, a 10Mb buffer is used to store the input stream. The output stream is then created from this which results in a 200k input being converted to a 10Mb output.
While reducing the size of the buffer may cause the buffer to be reused more often, the output size is closer to the input size.
Some benchmarks are available here: https://github.com/galkahana/HummusJS/issues/247