### PR TITLE
Solve nsp vulnerabilities due to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hummus",
-  "version": "1.0.84",
+  "version": "1.0.86",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -8,15 +8,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
-    },
-    "ajv": {
-      "version": "4.11.8",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-      "requires": {
-        "co": "4.6.0",
-        "json-stable-stringify": "1.0.1"
-      }
     },
     "ansi-regex": {
       "version": "2.1.1",
@@ -34,29 +25,14 @@
       "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
       "requires": {
         "delegates": "1.0.0",
-        "readable-stream": "2.3.3"
+        "readable-stream": "2.3.6"
       }
     },
-    "asn1": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
-    },
-    "assert-plus": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
-    },
     "assertion-error": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
-      "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true
-    },
-    "asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "aws-sdk": {
       "version": "2.0.31",
@@ -68,59 +44,19 @@
         "xmlbuilder": "0.4.2"
       }
     },
-    "aws-sign2": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-      "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
-    },
-    "aws4": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
-    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
-    "bcrypt-pbkdf": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-      "optional": true,
-      "requires": {
-        "tweetnacl": "0.14.5"
-      }
-    },
-    "block-stream": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-      "requires": {
-        "inherits": "2.0.3"
-      }
-    },
-    "boom": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-      "requires": {
-        "hoek": "2.16.3"
-      }
-    },
     "brace-expansion": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
         "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
-    },
-    "caseless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "chai": {
       "version": "3.5.0",
@@ -128,28 +64,20 @@
       "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
       "dev": true,
       "requires": {
-        "assertion-error": "1.0.2",
+        "assertion-error": "1.1.0",
         "deep-eql": "0.1.3",
         "type-detect": "1.0.0"
       }
     },
-    "co": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+    "chownr": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+      "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE="
     },
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
-    },
-    "combined-stream": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-      "requires": {
-        "delayed-stream": "1.0.0"
-      }
     },
     "commander": {
       "version": "2.3.0",
@@ -171,29 +99,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-    },
-    "cryptiles": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-      "requires": {
-        "boom": "2.10.1"
-      }
-    },
-    "dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "requires": {
-        "assert-plus": "1.0.0"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-        }
-      }
     },
     "debug": {
       "version": "2.6.9",
@@ -225,15 +130,15 @@
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
       "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
     },
-    "delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-    },
     "delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+    },
+    "detect-libc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
     },
     "diff": {
       "version": "1.4.0",
@@ -241,71 +146,24 @@
       "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
       "dev": true
     },
-    "ecc-jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-      "optional": true,
-      "requires": {
-        "jsbn": "0.1.1"
-      }
-    },
     "escape-string-regexp": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
       "integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE=",
       "dev": true
     },
-    "extend": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
-    },
-    "extsprintf": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
-    },
-    "forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
-    },
-    "form-data": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-      "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+    "fs-minipass": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+      "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
       "requires": {
-        "asynckit": "0.4.0",
-        "combined-stream": "1.0.5",
-        "mime-types": "2.1.17"
+        "minipass": "2.2.4"
       }
     },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-    },
-    "fstream": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "inherits": "2.0.3",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.2"
-      }
-    },
-    "fstream-ignore": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
-      "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
-      "requires": {
-        "fstream": "1.0.11",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4"
-      }
     },
     "gauge": {
       "version": "2.7.4",
@@ -322,21 +180,6 @@
         "wide-align": "1.1.2"
       }
     },
-    "getpass": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "requires": {
-        "assert-plus": "1.0.0"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-        }
-      }
-    },
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
@@ -350,60 +193,31 @@
         "path-is-absolute": "1.0.1"
       }
     },
-    "graceful-fs": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
-    },
     "growl": {
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
       "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
       "dev": true
     },
-    "har-schema": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-      "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4="
-    },
-    "har-validator": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-      "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
-      "requires": {
-        "ajv": "4.11.8",
-        "har-schema": "1.0.5"
-      }
-    },
     "has-unicode": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
     },
-    "hawk": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+    "iconv-lite": {
+      "version": "0.4.21",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.21.tgz",
+      "integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
       "requires": {
-        "boom": "2.10.1",
-        "cryptiles": "2.0.5",
-        "hoek": "2.16.3",
-        "sntp": "1.0.9"
+        "safer-buffer": "2.1.2"
       }
     },
-    "hoek": {
-      "version": "2.16.3",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
-    },
-    "http-signature": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-      "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+    "ignore-walk": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
+      "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
       "requires": {
-        "assert-plus": "0.2.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.13.1"
+        "minimatch": "3.0.4"
       }
     },
     "inflight": {
@@ -421,9 +235,9 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "ini": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-      "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4="
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
     },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
@@ -433,20 +247,10 @@
         "number-is-nan": "1.0.1"
       }
     },
-    "is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
-    },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-    },
-    "isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "jade": {
       "version": "0.26.3",
@@ -472,84 +276,41 @@
         }
       }
     },
-    "jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "optional": true
-    },
-    "json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
-    },
-    "json-stable-stringify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "requires": {
-        "jsonify": "0.0.0"
-      }
-    },
-    "json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-    },
-    "jsonify": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
-    },
-    "jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-      "requires": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
-        "verror": "1.10.0"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-        }
-      }
-    },
     "lru-cache": {
       "version": "2.7.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
       "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
       "dev": true
     },
-    "mime-db": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
-      "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
-    },
-    "mime-types": {
-      "version": "2.1.17",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
-      "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
-      "requires": {
-        "mime-db": "1.30.0"
-      }
-    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "1.1.8"
+        "brace-expansion": "1.1.11"
       }
     },
     "minimist": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+    },
+    "minipass": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
+      "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
+      "requires": {
+        "safe-buffer": "5.1.2",
+        "yallist": "3.0.2"
+      }
+    },
+    "minizlib": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
+      "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
+      "requires": {
+        "minipass": "2.2.4"
+      }
     },
     "mkdirp": {
       "version": "0.5.1",
@@ -619,21 +380,31 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
-    "node-pre-gyp": {
-      "version": "0.6.38",
-      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.38.tgz",
-      "integrity": "sha1-6Sog+DQWQVu0CG9tH7eLPac9ET0=",
+    "needle": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.0.tgz",
+      "integrity": "sha512-eFagy6c+TYayorXw/qtAdSvaUpEbBsDwDyxYFgLZ0lTojfH7K+OdBqAF7TAFwDokJaGpubpSGG0wO3iC0XPi8w==",
       "requires": {
-        "hawk": "3.1.3",
+        "debug": "2.6.9",
+        "iconv-lite": "0.4.21",
+        "sax": "1.2.4"
+      }
+    },
+    "node-pre-gyp": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.9.1.tgz",
+      "integrity": "sha1-8RwHUW3ZL4cZnbx+GDjqt81WyeA=",
+      "requires": {
+        "detect-libc": "1.0.3",
         "mkdirp": "0.5.1",
+        "needle": "2.2.0",
         "nopt": "4.0.1",
+        "npm-packlist": "1.1.10",
         "npmlog": "4.1.2",
-        "rc": "1.2.1",
-        "request": "2.81.0",
+        "rc": "1.2.6",
         "rimraf": "2.6.2",
-        "semver": "5.4.1",
-        "tar": "2.2.1",
-        "tar-pack": "3.4.0"
+        "semver": "5.5.0",
+        "tar": "4.4.1"
       }
     },
     "nopt": {
@@ -642,13 +413,14 @@
       "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
       "requires": {
         "abbrev": "1.1.1",
-        "osenv": "0.1.4"
+        "osenv": "0.1.5"
       }
     },
     "npm": {
       "version": "5.8.0",
       "resolved": "https://registry.npmjs.org/npm/-/npm-5.8.0.tgz",
-      "integrity": "sha1-Xkv7jC562gHdQewFVdE90PRG3bI=",
+      "integrity": "sha512-DowXzQwtSWDtbAjuWecuEiismR0VdNEYaL3VxNTYTdW6AGkYxfGk9LUZ/rt6etEyiH4IEk95HkJeGfXE5Rz9xQ==",
+      "dev": true,
       "requires": {
         "JSONStream": "1.3.2",
         "abbrev": "1.1.1",
@@ -764,6 +536,7 @@
         "JSONStream": {
           "version": "1.3.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "jsonparse": "1.3.1",
             "through": "2.3.8"
@@ -771,41 +544,50 @@
           "dependencies": {
             "jsonparse": {
               "version": "1.3.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "through": {
               "version": "2.3.8",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "abbrev": {
           "version": "1.1.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "ansi-regex": {
           "version": "3.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "ansicolors": {
           "version": "0.3.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "ansistyles": {
           "version": "0.1.3",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "archy": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "bin-links": {
           "version": "1.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "bluebird": "3.5.1",
             "cmd-shim": "2.0.2",
@@ -817,11 +599,13 @@
         },
         "bluebird": {
           "version": "3.5.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "cacache": {
           "version": "10.0.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "bluebird": "3.5.1",
             "chownr": "1.0.1",
@@ -841,6 +625,7 @@
             "mississippi": {
               "version": "2.0.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "concat-stream": "1.6.1",
                 "duplexify": "3.5.4",
@@ -857,6 +642,7 @@
                 "concat-stream": {
                   "version": "1.6.1",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "inherits": "2.0.3",
                     "readable-stream": "2.3.5",
@@ -865,13 +651,15 @@
                   "dependencies": {
                     "typedarray": {
                       "version": "0.0.6",
-                      "bundled": true
+                      "bundled": true,
+                      "dev": true
                     }
                   }
                 },
                 "duplexify": {
                   "version": "3.5.4",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "end-of-stream": "1.4.1",
                     "inherits": "2.0.3",
@@ -881,13 +669,15 @@
                   "dependencies": {
                     "stream-shift": {
                       "version": "1.0.0",
-                      "bundled": true
+                      "bundled": true,
+                      "dev": true
                     }
                   }
                 },
                 "end-of-stream": {
                   "version": "1.4.1",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "once": "1.4.0"
                   }
@@ -895,6 +685,7 @@
                 "flush-write-stream": {
                   "version": "1.0.2",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "inherits": "2.0.3",
                     "readable-stream": "2.3.5"
@@ -903,6 +694,7 @@
                 "from2": {
                   "version": "2.3.0",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "inherits": "2.0.3",
                     "readable-stream": "2.3.5"
@@ -911,6 +703,7 @@
                 "parallel-transform": {
                   "version": "1.1.0",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "cyclist": "0.2.2",
                     "inherits": "2.0.3",
@@ -919,13 +712,15 @@
                   "dependencies": {
                     "cyclist": {
                       "version": "0.2.2",
-                      "bundled": true
+                      "bundled": true,
+                      "dev": true
                     }
                   }
                 },
                 "pump": {
                   "version": "2.0.1",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "end-of-stream": "1.4.1",
                     "once": "1.4.0"
@@ -934,6 +729,7 @@
                 "pumpify": {
                   "version": "1.4.0",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "duplexify": "3.5.4",
                     "inherits": "2.0.3",
@@ -943,6 +739,7 @@
                 "stream-each": {
                   "version": "1.2.2",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "end-of-stream": "1.4.1",
                     "stream-shift": "1.0.0"
@@ -950,13 +747,15 @@
                   "dependencies": {
                     "stream-shift": {
                       "version": "1.0.0",
-                      "bundled": true
+                      "bundled": true,
+                      "dev": true
                     }
                   }
                 },
                 "through2": {
                   "version": "2.0.3",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "readable-stream": "2.3.5",
                     "xtend": "4.0.1"
@@ -964,7 +763,8 @@
                   "dependencies": {
                     "xtend": {
                       "version": "4.0.1",
-                      "bundled": true
+                      "bundled": true,
+                      "dev": true
                     }
                   }
                 }
@@ -972,21 +772,25 @@
             },
             "y18n": {
               "version": "4.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "call-limit": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "chownr": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "cli-table2": {
           "version": "0.2.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "colors": "1.1.2",
             "lodash": "3.10.1",
@@ -996,15 +800,18 @@
             "colors": {
               "version": "1.1.2",
               "bundled": true,
+              "dev": true,
               "optional": true
             },
             "lodash": {
               "version": "3.10.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "code-point-at": "1.1.0",
                 "is-fullwidth-code-point": "1.0.0",
@@ -1013,31 +820,36 @@
               "dependencies": {
                 "code-point-at": {
                   "version": "1.1.0",
-                  "bundled": true
+                  "bundled": true,
+                  "dev": true
                 },
                 "is-fullwidth-code-point": {
                   "version": "1.0.0",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "number-is-nan": "1.0.1"
                   },
                   "dependencies": {
                     "number-is-nan": {
                       "version": "1.0.1",
-                      "bundled": true
+                      "bundled": true,
+                      "dev": true
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "3.0.1",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "ansi-regex": "2.1.1"
                   },
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.1.1",
-                      "bundled": true
+                      "bundled": true,
+                      "dev": true
                     }
                   }
                 }
@@ -1048,6 +860,7 @@
         "cmd-shim": {
           "version": "2.0.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
             "mkdirp": "0.5.1"
@@ -1056,6 +869,7 @@
         "columnify": {
           "version": "1.5.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "strip-ansi": "3.0.1",
             "wcwidth": "1.0.1"
@@ -1064,19 +878,22 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "ansi-regex": "2.1.1"
               },
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.1.1",
-                  "bundled": true
+                  "bundled": true,
+                  "dev": true
                 }
               }
             },
             "wcwidth": {
               "version": "1.0.1",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "defaults": "1.0.3"
               },
@@ -1084,13 +901,15 @@
                 "defaults": {
                   "version": "1.0.3",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "clone": "1.0.2"
                   },
                   "dependencies": {
                     "clone": {
                       "version": "1.0.2",
-                      "bundled": true
+                      "bundled": true,
+                      "dev": true
                     }
                   }
                 }
@@ -1101,6 +920,7 @@
         "config-chain": {
           "version": "1.1.11",
           "bundled": true,
+          "dev": true,
           "requires": {
             "ini": "1.3.5",
             "proto-list": "1.2.4"
@@ -1108,25 +928,30 @@
           "dependencies": {
             "proto-list": {
               "version": "1.2.4",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "debuglog": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "detect-indent": {
           "version": "5.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "detect-newline": {
           "version": "2.1.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "dezalgo": {
           "version": "1.0.3",
           "bundled": true,
+          "dev": true,
           "requires": {
             "asap": "2.0.5",
             "wrappy": "1.0.2"
@@ -1134,21 +959,25 @@
           "dependencies": {
             "asap": {
               "version": "2.0.5",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "editor": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "find-npm-prefix": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "fs-vacuum": {
           "version": "1.2.10",
           "bundled": true,
+          "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
             "path-is-inside": "1.0.2",
@@ -1158,6 +987,7 @@
         "fs-write-stream-atomic": {
           "version": "1.0.10",
           "bundled": true,
+          "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
             "iferr": "0.1.5",
@@ -1168,6 +998,7 @@
         "gentle-fs": {
           "version": "2.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "aproba": "1.2.0",
             "fs-vacuum": "1.2.10",
@@ -1182,6 +1013,7 @@
         "glob": {
           "version": "7.1.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
             "inflight": "1.0.6",
@@ -1193,11 +1025,13 @@
           "dependencies": {
             "fs.realpath": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "brace-expansion": "1.1.8"
               },
@@ -1205,6 +1039,7 @@
                 "brace-expansion": {
                   "version": "1.1.8",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "balanced-match": "1.0.0",
                     "concat-map": "0.0.1"
@@ -1212,11 +1047,13 @@
                   "dependencies": {
                     "balanced-match": {
                       "version": "1.0.0",
-                      "bundled": true
+                      "bundled": true,
+                      "dev": true
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "bundled": true
+                      "bundled": true,
+                      "dev": true
                     }
                   }
                 }
@@ -1224,33 +1061,40 @@
             },
             "path-is-absolute": {
               "version": "1.0.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "graceful-fs": {
           "version": "4.1.11",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "has-unicode": {
           "version": "2.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "hosted-git-info": {
           "version": "2.6.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "iferr": {
           "version": "0.1.5",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "imurmurhash": {
           "version": "0.1.4",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "inflight": {
           "version": "1.0.6",
           "bundled": true,
+          "dev": true,
           "requires": {
             "once": "1.4.0",
             "wrappy": "1.0.2"
@@ -1258,15 +1102,18 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "init-package-json": {
           "version": "1.10.3",
           "bundled": true,
+          "dev": true,
           "requires": {
             "glob": "7.1.2",
             "npm-package-arg": "6.0.0",
@@ -1281,6 +1128,7 @@
             "promzard": {
               "version": "0.3.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "read": "1.0.7"
               }
@@ -1290,27 +1138,32 @@
         "is-cidr": {
           "version": "1.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "cidr-regex": "1.0.6"
           },
           "dependencies": {
             "cidr-regex": {
               "version": "1.0.6",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "json-parse-better-errors": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "lazy-property": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "libcipm": {
           "version": "1.6.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "bin-links": "1.1.0",
             "bluebird": "3.5.1",
@@ -1330,6 +1183,7 @@
             "lock-verify": {
               "version": "2.0.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "npm-package-arg": "5.1.2",
                 "semver": "5.5.0"
@@ -1338,6 +1192,7 @@
                 "npm-package-arg": {
                   "version": "5.1.2",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "hosted-git-info": "2.6.0",
                     "osenv": "0.1.5",
@@ -1349,24 +1204,28 @@
             },
             "npm-logical-tree": {
               "version": "1.2.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "protoduck": {
               "version": "5.0.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "genfun": "4.0.1"
               },
               "dependencies": {
                 "genfun": {
                   "version": "4.0.1",
-                  "bundled": true
+                  "bundled": true,
+                  "dev": true
                 }
               }
             },
             "worker-farm": {
               "version": "1.5.4",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "errno": "0.1.7",
                 "xtend": "4.0.1"
@@ -1375,19 +1234,22 @@
                 "errno": {
                   "version": "0.1.7",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "prr": "1.0.1"
                   },
                   "dependencies": {
                     "prr": {
                       "version": "1.0.1",
-                      "bundled": true
+                      "bundled": true,
+                      "dev": true
                     }
                   }
                 },
                 "xtend": {
                   "version": "4.0.1",
-                  "bundled": true
+                  "bundled": true,
+                  "dev": true
                 }
               }
             }
@@ -1396,6 +1258,7 @@
         "libnpx": {
           "version": "10.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "dotenv": "5.0.1",
             "npm-package-arg": "6.0.0",
@@ -1409,15 +1272,18 @@
           "dependencies": {
             "dotenv": {
               "version": "5.0.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "y18n": {
               "version": "4.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "yargs": {
               "version": "11.0.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "cliui": "4.0.0",
                 "decamelize": "1.2.0",
@@ -1436,6 +1302,7 @@
                 "cliui": {
                   "version": "4.0.0",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "string-width": "2.1.1",
                     "strip-ansi": "4.0.0",
@@ -1445,6 +1312,7 @@
                     "wrap-ansi": {
                       "version": "2.1.0",
                       "bundled": true,
+                      "dev": true,
                       "requires": {
                         "string-width": "1.0.2",
                         "strip-ansi": "3.0.1"
@@ -1453,6 +1321,7 @@
                         "string-width": {
                           "version": "1.0.2",
                           "bundled": true,
+                          "dev": true,
                           "requires": {
                             "code-point-at": "1.1.0",
                             "is-fullwidth-code-point": "1.0.0",
@@ -1461,18 +1330,21 @@
                           "dependencies": {
                             "code-point-at": {
                               "version": "1.1.0",
-                              "bundled": true
+                              "bundled": true,
+                              "dev": true
                             },
                             "is-fullwidth-code-point": {
                               "version": "1.0.0",
                               "bundled": true,
+                              "dev": true,
                               "requires": {
                                 "number-is-nan": "1.0.1"
                               },
                               "dependencies": {
                                 "number-is-nan": {
                                   "version": "1.0.1",
-                                  "bundled": true
+                                  "bundled": true,
+                                  "dev": true
                                 }
                               }
                             }
@@ -1481,13 +1353,15 @@
                         "strip-ansi": {
                           "version": "3.0.1",
                           "bundled": true,
+                          "dev": true,
                           "requires": {
                             "ansi-regex": "2.1.1"
                           },
                           "dependencies": {
                             "ansi-regex": {
                               "version": "2.1.1",
-                              "bundled": true
+                              "bundled": true,
+                              "dev": true
                             }
                           }
                         }
@@ -1497,11 +1371,13 @@
                 },
                 "decamelize": {
                   "version": "1.2.0",
-                  "bundled": true
+                  "bundled": true,
+                  "dev": true
                 },
                 "find-up": {
                   "version": "2.1.0",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "locate-path": "2.0.0"
                   },
@@ -1509,6 +1385,7 @@
                     "locate-path": {
                       "version": "2.0.0",
                       "bundled": true,
+                      "dev": true,
                       "requires": {
                         "p-locate": "2.0.0",
                         "path-exists": "3.0.0"
@@ -1517,6 +1394,7 @@
                         "p-locate": {
                           "version": "2.0.0",
                           "bundled": true,
+                          "dev": true,
                           "requires": {
                             "p-limit": "1.2.0"
                           },
@@ -1524,13 +1402,15 @@
                             "p-limit": {
                               "version": "1.2.0",
                               "bundled": true,
+                              "dev": true,
                               "requires": {
                                 "p-try": "1.0.0"
                               },
                               "dependencies": {
                                 "p-try": {
                                   "version": "1.0.0",
-                                  "bundled": true
+                                  "bundled": true,
+                                  "dev": true
                                 }
                               }
                             }
@@ -1538,7 +1418,8 @@
                         },
                         "path-exists": {
                           "version": "3.0.0",
-                          "bundled": true
+                          "bundled": true,
+                          "dev": true
                         }
                       }
                     }
@@ -1546,11 +1427,13 @@
                 },
                 "get-caller-file": {
                   "version": "1.0.2",
-                  "bundled": true
+                  "bundled": true,
+                  "dev": true
                 },
                 "os-locale": {
                   "version": "2.1.0",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "execa": "0.7.0",
                     "lcid": "1.0.0",
@@ -1560,6 +1443,7 @@
                     "execa": {
                       "version": "0.7.0",
                       "bundled": true,
+                      "dev": true,
                       "requires": {
                         "cross-spawn": "5.1.0",
                         "get-stream": "3.0.0",
@@ -1573,6 +1457,7 @@
                         "cross-spawn": {
                           "version": "5.1.0",
                           "bundled": true,
+                          "dev": true,
                           "requires": {
                             "lru-cache": "4.1.1",
                             "shebang-command": "1.2.0",
@@ -1582,13 +1467,15 @@
                             "shebang-command": {
                               "version": "1.2.0",
                               "bundled": true,
+                              "dev": true,
                               "requires": {
                                 "shebang-regex": "1.0.0"
                               },
                               "dependencies": {
                                 "shebang-regex": {
                                   "version": "1.0.0",
-                                  "bundled": true
+                                  "bundled": true,
+                                  "dev": true
                                 }
                               }
                             }
@@ -1596,62 +1483,73 @@
                         },
                         "get-stream": {
                           "version": "3.0.0",
-                          "bundled": true
+                          "bundled": true,
+                          "dev": true
                         },
                         "is-stream": {
                           "version": "1.1.0",
-                          "bundled": true
+                          "bundled": true,
+                          "dev": true
                         },
                         "npm-run-path": {
                           "version": "2.0.2",
                           "bundled": true,
+                          "dev": true,
                           "requires": {
                             "path-key": "2.0.1"
                           },
                           "dependencies": {
                             "path-key": {
                               "version": "2.0.1",
-                              "bundled": true
+                              "bundled": true,
+                              "dev": true
                             }
                           }
                         },
                         "p-finally": {
                           "version": "1.0.0",
-                          "bundled": true
+                          "bundled": true,
+                          "dev": true
                         },
                         "signal-exit": {
                           "version": "3.0.2",
-                          "bundled": true
+                          "bundled": true,
+                          "dev": true
                         },
                         "strip-eof": {
                           "version": "1.0.0",
-                          "bundled": true
+                          "bundled": true,
+                          "dev": true
                         }
                       }
                     },
                     "lcid": {
                       "version": "1.0.0",
                       "bundled": true,
+                      "dev": true,
                       "requires": {
                         "invert-kv": "1.0.0"
                       },
                       "dependencies": {
                         "invert-kv": {
                           "version": "1.0.0",
-                          "bundled": true
+                          "bundled": true,
+                          "dev": true
                         }
                       }
                     },
                     "mem": {
                       "version": "1.1.0",
                       "bundled": true,
+                      "dev": true,
                       "requires": {
                         "mimic-fn": "1.2.0"
                       },
                       "dependencies": {
                         "mimic-fn": {
                           "version": "1.2.0",
-                          "bundled": true
+                          "bundled": true,
+                          "dev": true
                         }
                       }
                     }
@@ -1659,19 +1557,23 @@
                 },
                 "require-directory": {
                   "version": "2.1.1",
-                  "bundled": true
+                  "bundled": true,
+                  "dev": true
                 },
                 "require-main-filename": {
                   "version": "1.0.1",
-                  "bundled": true
+                  "bundled": true,
+                  "dev": true
                 },
                 "set-blocking": {
                   "version": "2.0.0",
-                  "bundled": true
+                  "bundled": true,
+                  "dev": true
                 },
                 "string-width": {
                   "version": "2.1.1",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "is-fullwidth-code-point": "2.0.0",
                     "strip-ansi": "4.0.0"
@@ -1679,28 +1581,33 @@
                   "dependencies": {
                     "is-fullwidth-code-point": {
                       "version": "2.0.0",
-                      "bundled": true
+                      "bundled": true,
+                      "dev": true
                     }
                   }
                 },
                 "which-module": {
                   "version": "2.0.0",
-                  "bundled": true
+                  "bundled": true,
+                  "dev": true
                 },
                 "y18n": {
                   "version": "3.2.1",
-                  "bundled": true
+                  "bundled": true,
+                  "dev": true
                 },
                 "yargs-parser": {
                   "version": "9.0.2",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "camelcase": "4.1.0"
                   },
                   "dependencies": {
                     "camelcase": {
                       "version": "4.1.0",
-                      "bundled": true
+                      "bundled": true,
+                      "dev": true
                     }
                   }
                 }
@@ -1710,15 +1617,18 @@
         },
         "lockfile": {
           "version": "1.0.3",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "lodash._baseindexof": {
           "version": "3.1.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "lodash._baseuniq": {
           "version": "4.6.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "lodash._createset": "4.0.3",
             "lodash._root": "3.0.1"
@@ -1726,56 +1636,68 @@
           "dependencies": {
             "lodash._createset": {
               "version": "4.0.3",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "lodash._root": {
               "version": "3.0.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "lodash._bindcallback": {
           "version": "3.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "lodash._cacheindexof": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "lodash._createcache": {
           "version": "3.1.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "lodash._getnative": "3.9.1"
           }
         },
         "lodash._getnative": {
           "version": "3.9.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "lodash.clonedeep": {
           "version": "4.5.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "lodash.restparam": {
           "version": "3.6.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "lodash.union": {
           "version": "4.6.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "lodash.uniq": {
           "version": "4.5.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "lodash.without": {
           "version": "4.4.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "lru-cache": {
           "version": "4.1.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "pseudomap": "1.0.2",
             "yallist": "2.1.2"
@@ -1783,21 +1705,25 @@
           "dependencies": {
             "pseudomap": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "yallist": {
               "version": "2.1.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "meant": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "mississippi": {
           "version": "3.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "concat-stream": "1.6.1",
             "duplexify": "3.5.4",
@@ -1814,6 +1740,7 @@
             "concat-stream": {
               "version": "1.6.1",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "inherits": "2.0.3",
                 "readable-stream": "2.3.5",
@@ -1822,13 +1749,15 @@
               "dependencies": {
                 "typedarray": {
                   "version": "0.0.6",
-                  "bundled": true
+                  "bundled": true,
+                  "dev": true
                 }
               }
             },
             "duplexify": {
               "version": "3.5.4",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "end-of-stream": "1.4.1",
                 "inherits": "2.0.3",
@@ -1838,13 +1767,15 @@
               "dependencies": {
                 "stream-shift": {
                   "version": "1.0.0",
-                  "bundled": true
+                  "bundled": true,
+                  "dev": true
                 }
               }
             },
             "end-of-stream": {
               "version": "1.4.1",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "once": "1.4.0"
               }
@@ -1852,6 +1783,7 @@
             "flush-write-stream": {
               "version": "1.0.2",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "inherits": "2.0.3",
                 "readable-stream": "2.3.5"
@@ -1860,6 +1792,7 @@
             "from2": {
               "version": "2.3.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "inherits": "2.0.3",
                 "readable-stream": "2.3.5"
@@ -1868,6 +1801,7 @@
             "parallel-transform": {
               "version": "1.1.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "cyclist": "0.2.2",
                 "inherits": "2.0.3",
@@ -1876,13 +1810,15 @@
               "dependencies": {
                 "cyclist": {
                   "version": "0.2.2",
-                  "bundled": true
+                  "bundled": true,
+                  "dev": true
                 }
               }
             },
             "pump": {
               "version": "3.0.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "end-of-stream": "1.4.1",
                 "once": "1.4.0"
@@ -1891,6 +1827,7 @@
             "pumpify": {
               "version": "1.4.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "duplexify": "3.5.4",
                 "inherits": "2.0.3",
@@ -1900,6 +1837,7 @@
                 "pump": {
                   "version": "2.0.1",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "end-of-stream": "1.4.1",
                     "once": "1.4.0"
@@ -1910,6 +1848,7 @@
             "stream-each": {
               "version": "1.2.2",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "end-of-stream": "1.4.1",
                 "stream-shift": "1.0.0"
@@ -1917,13 +1856,15 @@
               "dependencies": {
                 "stream-shift": {
                   "version": "1.0.0",
-                  "bundled": true
+                  "bundled": true,
+                  "dev": true
                 }
               }
             },
             "through2": {
               "version": "2.0.3",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "readable-stream": "2.3.5",
                 "xtend": "4.0.1"
@@ -1931,7 +1872,8 @@
               "dependencies": {
                 "xtend": {
                   "version": "4.0.1",
-                  "bundled": true
+                  "bundled": true,
+                  "dev": true
                 }
               }
             }
@@ -1940,19 +1882,22 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "minimist": "0.0.8"
           },
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "move-concurrently": {
           "version": "1.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "aproba": "1.2.0",
             "copy-concurrently": "1.0.5",
@@ -1965,6 +1910,7 @@
             "copy-concurrently": {
               "version": "1.0.5",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "aproba": "1.2.0",
                 "fs-write-stream-atomic": "1.0.10",
@@ -1977,6 +1923,7 @@
             "run-queue": {
               "version": "1.0.3",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "aproba": "1.2.0"
               }
@@ -1986,6 +1933,7 @@
         "nopt": {
           "version": "4.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "abbrev": "1.1.1",
             "osenv": "0.1.5"
@@ -1994,6 +1942,7 @@
         "normalize-package-data": {
           "version": "2.4.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "hosted-git-info": "2.6.0",
             "is-builtin-module": "1.0.0",
@@ -2004,13 +1953,15 @@
             "is-builtin-module": {
               "version": "1.0.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "builtin-modules": "1.1.1"
               },
               "dependencies": {
                 "builtin-modules": {
                   "version": "1.1.1",
-                  "bundled": true
+                  "bundled": true,
+                  "dev": true
                 }
               }
             }
@@ -2018,11 +1969,13 @@
         },
         "npm-cache-filename": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "npm-install-checks": {
           "version": "3.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "semver": "5.5.0"
           }
@@ -2030,6 +1983,7 @@
         "npm-lifecycle": {
           "version": "2.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "byline": "5.0.0",
             "graceful-fs": "4.1.11",
@@ -2043,11 +1997,13 @@
           "dependencies": {
             "byline": {
               "version": "5.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "node-gyp": {
               "version": "3.6.2",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "fstream": "1.0.11",
                 "glob": "7.1.2",
@@ -2067,6 +2023,7 @@
                 "fstream": {
                   "version": "1.0.11",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "graceful-fs": "4.1.11",
                     "inherits": "2.0.3",
@@ -2077,6 +2034,7 @@
                 "minimatch": {
                   "version": "3.0.4",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "brace-expansion": "1.1.11"
                   },
@@ -2084,6 +2042,7 @@
                     "brace-expansion": {
                       "version": "1.1.11",
                       "bundled": true,
+                      "dev": true,
                       "requires": {
                         "balanced-match": "1.0.0",
                         "concat-map": "0.0.1"
@@ -2091,11 +2050,13 @@
                       "dependencies": {
                         "balanced-match": {
                           "version": "1.0.0",
-                          "bundled": true
+                          "bundled": true,
+                          "dev": true
                         },
                         "concat-map": {
                           "version": "0.0.1",
-                          "bundled": true
+                          "bundled": true,
+                          "dev": true
                         }
                       }
                     }
@@ -2104,17 +2065,20 @@
                 "nopt": {
                   "version": "3.0.6",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "abbrev": "1.1.1"
                   }
                 },
                 "semver": {
                   "version": "5.3.0",
-                  "bundled": true
+                  "bundled": true,
+                  "dev": true
                 },
                 "tar": {
                   "version": "2.2.1",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "block-stream": "0.0.9",
                     "fstream": "1.0.11",
@@ -2124,6 +2088,7 @@
                     "block-stream": {
                       "version": "0.0.9",
                       "bundled": true,
+                      "dev": true,
                       "requires": {
                         "inherits": "2.0.3"
                       }
@@ -2134,13 +2099,15 @@
             },
             "resolve-from": {
               "version": "4.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "npm-package-arg": {
           "version": "6.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "hosted-git-info": "2.6.0",
             "osenv": "0.1.5",
@@ -2151,6 +2118,7 @@
         "npm-packlist": {
           "version": "1.1.10",
           "bundled": true,
+          "dev": true,
           "requires": {
             "ignore-walk": "3.0.1",
             "npm-bundled": "1.0.3"
@@ -2159,6 +2127,7 @@
             "ignore-walk": {
               "version": "3.0.1",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "minimatch": "3.0.4"
               },
@@ -2166,6 +2135,7 @@
                 "minimatch": {
                   "version": "3.0.4",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "brace-expansion": "1.1.8"
                   },
@@ -2173,6 +2143,7 @@
                     "brace-expansion": {
                       "version": "1.1.8",
                       "bundled": true,
+                      "dev": true,
                       "requires": {
                         "balanced-match": "1.0.0",
                         "concat-map": "0.0.1"
@@ -2180,11 +2151,13 @@
                       "dependencies": {
                         "balanced-match": {
                           "version": "1.0.0",
-                          "bundled": true
+                          "bundled": true,
+                          "dev": true
                         },
                         "concat-map": {
                           "version": "0.0.1",
-                          "bundled": true
+                          "bundled": true,
+                          "dev": true
                         }
                       }
                     }
@@ -2194,13 +2167,15 @@
             },
             "npm-bundled": {
               "version": "1.0.3",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "npm-profile": {
           "version": "3.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "aproba": "1.2.0",
             "make-fetch-happen": "2.6.0"
@@ -2209,6 +2184,7 @@
             "make-fetch-happen": {
               "version": "2.6.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "agentkeepalive": "3.3.0",
                 "cacache": "10.0.4",
@@ -2226,6 +2202,7 @@
                 "agentkeepalive": {
                   "version": "3.3.0",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "humanize-ms": "1.2.1"
                   },
@@ -2233,13 +2210,15 @@
                     "humanize-ms": {
                       "version": "1.2.1",
                       "bundled": true,
+                      "dev": true,
                       "requires": {
                         "ms": "2.1.1"
                       },
                       "dependencies": {
                         "ms": {
                           "version": "2.1.1",
-                          "bundled": true
+                          "bundled": true,
+                          "dev": true
                         }
                       }
                     }
@@ -2247,11 +2226,13 @@
                 },
                 "http-cache-semantics": {
                   "version": "3.8.1",
-                  "bundled": true
+                  "bundled": true,
+                  "dev": true
                 },
                 "http-proxy-agent": {
                   "version": "2.0.0",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "agent-base": "4.2.0",
                     "debug": "2.6.9"
@@ -2260,6 +2241,7 @@
                     "agent-base": {
                       "version": "4.2.0",
                       "bundled": true,
+                      "dev": true,
                       "requires": {
                         "es6-promisify": "5.0.0"
                       },
@@ -2267,13 +2249,15 @@
                         "es6-promisify": {
                           "version": "5.0.0",
                           "bundled": true,
+                          "dev": true,
                           "requires": {
                             "es6-promise": "4.2.4"
                           },
                           "dependencies": {
                             "es6-promise": {
                               "version": "4.2.4",
-                              "bundled": true
+                              "bundled": true,
+                              "dev": true
                             }
                           }
                         }
@@ -2282,13 +2266,15 @@
                     "debug": {
                       "version": "2.6.9",
                       "bundled": true,
+                      "dev": true,
                       "requires": {
                         "ms": "2.0.0"
                       },
                       "dependencies": {
                         "ms": {
                           "version": "2.0.0",
-                          "bundled": true
+                          "bundled": true,
+                          "dev": true
                         }
                       }
                     }
@@ -2297,6 +2283,7 @@
                 "https-proxy-agent": {
                   "version": "2.1.1",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "agent-base": "4.2.0",
                     "debug": "3.1.0"
@@ -2305,6 +2292,7 @@
                     "agent-base": {
                       "version": "4.2.0",
                       "bundled": true,
+                      "dev": true,
                       "requires": {
                         "es6-promisify": "5.0.0"
                       },
@@ -2312,13 +2300,15 @@
                         "es6-promisify": {
                           "version": "5.0.0",
                           "bundled": true,
+                          "dev": true,
                           "requires": {
                             "es6-promise": "4.2.4"
                           },
                           "dependencies": {
                             "es6-promise": {
                               "version": "4.2.4",
-                              "bundled": true
+                              "bundled": true,
+                              "dev": true
                             }
                           }
                         }
@@ -2327,13 +2317,15 @@
                     "debug": {
                       "version": "3.1.0",
                       "bundled": true,
+                      "dev": true,
                       "requires": {
                         "ms": "2.0.0"
                       },
                       "dependencies": {
                         "ms": {
                           "version": "2.0.0",
-                          "bundled": true
+                          "bundled": true,
+                          "dev": true
                         }
                       }
                     }
@@ -2342,6 +2334,7 @@
                 "mississippi": {
                   "version": "1.3.1",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "concat-stream": "1.6.0",
                     "duplexify": "3.5.3",
@@ -2358,6 +2351,7 @@
                     "concat-stream": {
                       "version": "1.6.0",
                       "bundled": true,
+                      "dev": true,
                       "requires": {
                         "inherits": "2.0.3",
                         "readable-stream": "2.3.5",
@@ -2366,13 +2360,15 @@
                       "dependencies": {
                         "typedarray": {
                           "version": "0.0.6",
-                          "bundled": true
+                          "bundled": true,
+                          "dev": true
                         }
                       }
                     },
                     "duplexify": {
                       "version": "3.5.3",
                       "bundled": true,
+                      "dev": true,
                       "requires": {
                         "end-of-stream": "1.4.1",
                         "inherits": "2.0.3",
@@ -2382,13 +2378,15 @@
                       "dependencies": {
                         "stream-shift": {
                           "version": "1.0.0",
-                          "bundled": true
+                          "bundled": true,
+                          "dev": true
                         }
                       }
                     },
                     "end-of-stream": {
                       "version": "1.4.1",
                       "bundled": true,
+                      "dev": true,
                       "requires": {
                         "once": "1.4.0"
                       }
@@ -2396,6 +2394,7 @@
                     "flush-write-stream": {
                       "version": "1.0.2",
                       "bundled": true,
+                      "dev": true,
                       "requires": {
                         "inherits": "2.0.3",
                         "readable-stream": "2.3.5"
@@ -2404,6 +2403,7 @@
                     "from2": {
                       "version": "2.3.0",
                       "bundled": true,
+                      "dev": true,
                       "requires": {
                         "inherits": "2.0.3",
                         "readable-stream": "2.3.5"
@@ -2412,6 +2412,7 @@
                     "parallel-transform": {
                       "version": "1.1.0",
                       "bundled": true,
+                      "dev": true,
                       "requires": {
                         "cyclist": "0.2.2",
                         "inherits": "2.0.3",
@@ -2420,13 +2421,15 @@
                       "dependencies": {
                         "cyclist": {
                           "version": "0.2.2",
-                          "bundled": true
+                          "bundled": true,
+                          "dev": true
                         }
                       }
                     },
                     "pump": {
                       "version": "1.0.3",
                       "bundled": true,
+                      "dev": true,
                       "requires": {
                         "end-of-stream": "1.4.1",
                         "once": "1.4.0"
@@ -2435,6 +2438,7 @@
                     "pumpify": {
                       "version": "1.4.0",
                       "bundled": true,
+                      "dev": true,
                       "requires": {
                         "duplexify": "3.5.3",
                         "inherits": "2.0.3",
@@ -2444,6 +2448,7 @@
                         "pump": {
                           "version": "2.0.1",
                           "bundled": true,
+                          "dev": true,
                           "requires": {
                             "end-of-stream": "1.4.1",
                             "once": "1.4.0"
@@ -2454,6 +2459,7 @@
                     "stream-each": {
                       "version": "1.2.2",
                       "bundled": true,
+                      "dev": true,
                       "requires": {
                         "end-of-stream": "1.4.1",
                         "stream-shift": "1.0.0"
@@ -2461,13 +2467,15 @@
                       "dependencies": {
                         "stream-shift": {
                           "version": "1.0.0",
-                          "bundled": true
+                          "bundled": true,
+                          "dev": true
                         }
                       }
                     },
                     "through2": {
                       "version": "2.0.3",
                       "bundled": true,
+                      "dev": true,
                       "requires": {
                         "readable-stream": "2.3.5",
                         "xtend": "4.0.1"
@@ -2475,7 +2483,8 @@
                       "dependencies": {
                         "xtend": {
                           "version": "4.0.1",
-                          "bundled": true
+                          "bundled": true,
+                          "dev": true
                         }
                       }
                     }
@@ -2484,6 +2493,7 @@
                 "node-fetch-npm": {
                   "version": "2.0.2",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "encoding": "0.1.12",
                     "json-parse-better-errors": "1.0.1",
@@ -2493,25 +2503,29 @@
                     "encoding": {
                       "version": "0.1.12",
                       "bundled": true,
+                      "dev": true,
                       "requires": {
                         "iconv-lite": "0.4.19"
                       },
                       "dependencies": {
                         "iconv-lite": {
                           "version": "0.4.19",
-                          "bundled": true
+                          "bundled": true,
+                          "dev": true
                         }
                       }
                     },
                     "json-parse-better-errors": {
                       "version": "1.0.1",
-                      "bundled": true
+                      "bundled": true,
+                      "dev": true
                     }
                   }
                 },
                 "promise-retry": {
                   "version": "1.1.1",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "err-code": "1.1.2",
                     "retry": "0.10.1"
@@ -2519,13 +2533,15 @@
                   "dependencies": {
                     "err-code": {
                       "version": "1.1.2",
-                      "bundled": true
+                      "bundled": true,
+                      "dev": true
                     }
                   }
                 },
                 "socks-proxy-agent": {
                   "version": "3.0.1",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "agent-base": "4.2.0",
                     "socks": "1.1.10"
@@ -2534,6 +2550,7 @@
                     "agent-base": {
                       "version": "4.2.0",
                       "bundled": true,
+                      "dev": true,
                       "requires": {
                         "es6-promisify": "5.0.0"
                       },
@@ -2541,13 +2558,15 @@
                         "es6-promisify": {
                           "version": "5.0.0",
                           "bundled": true,
+                          "dev": true,
                           "requires": {
                             "es6-promise": "4.2.4"
                           },
                           "dependencies": {
                             "es6-promise": {
                               "version": "4.2.4",
-                              "bundled": true
+                              "bundled": true,
+                              "dev": true
                             }
                           }
                         }
@@ -2556,6 +2575,7 @@
                     "socks": {
                       "version": "1.1.10",
                       "bundled": true,
+                      "dev": true,
                       "requires": {
                         "ip": "1.1.5",
                         "smart-buffer": "1.1.15"
@@ -2563,11 +2583,13 @@
                       "dependencies": {
                         "ip": {
                           "version": "1.1.5",
-                          "bundled": true
+                          "bundled": true,
+                          "dev": true
                         },
                         "smart-buffer": {
                           "version": "1.1.15",
-                          "bundled": true
+                          "bundled": true,
+                          "dev": true
                         }
                       }
                     }
@@ -2580,6 +2602,7 @@
         "npm-registry-client": {
           "version": "8.5.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "concat-stream": "1.6.1",
             "graceful-fs": "4.1.11",
@@ -2598,6 +2621,7 @@
             "concat-stream": {
               "version": "1.6.1",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "inherits": "2.0.3",
                 "readable-stream": "2.3.5",
@@ -2606,7 +2630,8 @@
               "dependencies": {
                 "typedarray": {
                   "version": "0.0.6",
-                  "bundled": true
+                  "bundled": true,
+                  "dev": true
                 }
               }
             }
@@ -2614,11 +2639,13 @@
         },
         "npm-user-validate": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "npmlog": {
           "version": "4.1.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "are-we-there-yet": "1.1.4",
             "console-control-strings": "1.1.0",
@@ -2629,6 +2656,7 @@
             "are-we-there-yet": {
               "version": "1.1.4",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "delegates": "1.0.0",
                 "readable-stream": "2.3.5"
@@ -2636,17 +2664,20 @@
               "dependencies": {
                 "delegates": {
                   "version": "1.0.0",
-                  "bundled": true
+                  "bundled": true,
+                  "dev": true
                 }
               }
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "gauge": {
               "version": "2.7.4",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "aproba": "1.2.0",
                 "console-control-strings": "1.1.0",
@@ -2660,15 +2691,18 @@
               "dependencies": {
                 "object-assign": {
                   "version": "4.1.1",
-                  "bundled": true
+                  "bundled": true,
+                  "dev": true
                 },
                 "signal-exit": {
                   "version": "3.0.2",
-                  "bundled": true
+                  "bundled": true,
+                  "dev": true
                 },
                 "string-width": {
                   "version": "1.0.2",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "code-point-at": "1.1.0",
                     "is-fullwidth-code-point": "1.0.0",
@@ -2677,18 +2711,21 @@
                   "dependencies": {
                     "code-point-at": {
                       "version": "1.1.0",
-                      "bundled": true
+                      "bundled": true,
+                      "dev": true
                     },
                     "is-fullwidth-code-point": {
                       "version": "1.0.0",
                       "bundled": true,
+                      "dev": true,
                       "requires": {
                         "number-is-nan": "1.0.1"
                       },
                       "dependencies": {
                         "number-is-nan": {
                           "version": "1.0.1",
-                          "bundled": true
+                          "bundled": true,
+                          "dev": true
                         }
                       }
                     }
@@ -2697,19 +2734,22 @@
                 "strip-ansi": {
                   "version": "3.0.1",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "ansi-regex": "2.1.1"
                   },
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.1.1",
-                      "bundled": true
+                      "bundled": true,
+                      "dev": true
                     }
                   }
                 },
                 "wide-align": {
                   "version": "1.1.2",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "string-width": "1.0.2"
                   }
@@ -2718,24 +2758,28 @@
             },
             "set-blocking": {
               "version": "2.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "wrappy": "1.0.2"
           }
         },
         "opener": {
           "version": "1.4.3",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "osenv": {
           "version": "0.1.5",
           "bundled": true,
+          "dev": true,
           "requires": {
             "os-homedir": "1.0.2",
             "os-tmpdir": "1.0.2"
@@ -2743,17 +2787,20 @@
           "dependencies": {
             "os-homedir": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "os-tmpdir": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "pacote": {
           "version": "7.6.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "bluebird": "3.5.1",
             "cacache": "10.0.4",
@@ -2783,11 +2830,13 @@
           "dependencies": {
             "get-stream": {
               "version": "3.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "make-fetch-happen": {
               "version": "2.6.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "agentkeepalive": "3.4.0",
                 "cacache": "10.0.4",
@@ -2805,6 +2854,7 @@
                 "agentkeepalive": {
                   "version": "3.4.0",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "humanize-ms": "1.2.1"
                   },
@@ -2812,13 +2862,15 @@
                     "humanize-ms": {
                       "version": "1.2.1",
                       "bundled": true,
+                      "dev": true,
                       "requires": {
                         "ms": "2.1.1"
                       },
                       "dependencies": {
                         "ms": {
                           "version": "2.1.1",
-                          "bundled": true
+                          "bundled": true,
+                          "dev": true
                         }
                       }
                     }
@@ -2826,11 +2878,13 @@
                 },
                 "http-cache-semantics": {
                   "version": "3.8.1",
-                  "bundled": true
+                  "bundled": true,
+                  "dev": true
                 },
                 "http-proxy-agent": {
                   "version": "2.1.0",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "agent-base": "4.2.0",
                     "debug": "3.1.0"
@@ -2839,6 +2893,7 @@
                     "agent-base": {
                       "version": "4.2.0",
                       "bundled": true,
+                      "dev": true,
                       "requires": {
                         "es6-promisify": "5.0.0"
                       },
@@ -2846,13 +2901,15 @@
                         "es6-promisify": {
                           "version": "5.0.0",
                           "bundled": true,
+                          "dev": true,
                           "requires": {
                             "es6-promise": "4.2.4"
                           },
                           "dependencies": {
                             "es6-promise": {
                               "version": "4.2.4",
-                              "bundled": true
+                              "bundled": true,
+                              "dev": true
                             }
                           }
                         }
@@ -2861,13 +2918,15 @@
                     "debug": {
                       "version": "3.1.0",
                       "bundled": true,
+                      "dev": true,
                       "requires": {
                         "ms": "2.0.0"
                       },
                       "dependencies": {
                         "ms": {
                           "version": "2.0.0",
-                          "bundled": true
+                          "bundled": true,
+                          "dev": true
                         }
                       }
                     }
@@ -2876,6 +2935,7 @@
                 "https-proxy-agent": {
                   "version": "2.2.0",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "agent-base": "4.2.0",
                     "debug": "3.1.0"
@@ -2884,6 +2944,7 @@
                     "agent-base": {
                       "version": "4.2.0",
                       "bundled": true,
+                      "dev": true,
                       "requires": {
                         "es6-promisify": "5.0.0"
                       },
@@ -2891,13 +2952,15 @@
                         "es6-promisify": {
                           "version": "5.0.0",
                           "bundled": true,
+                          "dev": true,
                           "requires": {
                             "es6-promise": "4.2.4"
                           },
                           "dependencies": {
                             "es6-promise": {
                               "version": "4.2.4",
-                              "bundled": true
+                              "bundled": true,
+                              "dev": true
                             }
                           }
                         }
@@ -2906,13 +2969,15 @@
                     "debug": {
                       "version": "3.1.0",
                       "bundled": true,
+                      "dev": true,
                       "requires": {
                         "ms": "2.0.0"
                       },
                       "dependencies": {
                         "ms": {
                           "version": "2.0.0",
-                          "bundled": true
+                          "bundled": true,
+                          "dev": true
                         }
                       }
                     }
@@ -2921,6 +2986,7 @@
                 "mississippi": {
                   "version": "1.3.1",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "concat-stream": "1.6.1",
                     "duplexify": "3.5.4",
@@ -2937,6 +3003,7 @@
                     "concat-stream": {
                       "version": "1.6.1",
                       "bundled": true,
+                      "dev": true,
                       "requires": {
                         "inherits": "2.0.3",
                         "readable-stream": "2.3.5",
@@ -2945,13 +3012,15 @@
                       "dependencies": {
                         "typedarray": {
                           "version": "0.0.6",
-                          "bundled": true
+                          "bundled": true,
+                          "dev": true
                         }
                       }
                     },
                     "duplexify": {
                       "version": "3.5.4",
                       "bundled": true,
+                      "dev": true,
                       "requires": {
                         "end-of-stream": "1.4.1",
                         "inherits": "2.0.3",
@@ -2961,13 +3030,15 @@
                       "dependencies": {
                         "stream-shift": {
                           "version": "1.0.0",
-                          "bundled": true
+                          "bundled": true,
+                          "dev": true
                         }
                       }
                     },
                     "end-of-stream": {
                       "version": "1.4.1",
                       "bundled": true,
+                      "dev": true,
                       "requires": {
                         "once": "1.4.0"
                       }
@@ -2975,6 +3046,7 @@
                     "flush-write-stream": {
                       "version": "1.0.2",
                       "bundled": true,
+                      "dev": true,
                       "requires": {
                         "inherits": "2.0.3",
                         "readable-stream": "2.3.5"
@@ -2983,6 +3055,7 @@
                     "from2": {
                       "version": "2.3.0",
                       "bundled": true,
+                      "dev": true,
                       "requires": {
                         "inherits": "2.0.3",
                         "readable-stream": "2.3.5"
@@ -2991,6 +3064,7 @@
                     "parallel-transform": {
                       "version": "1.1.0",
                       "bundled": true,
+                      "dev": true,
                       "requires": {
                         "cyclist": "0.2.2",
                         "inherits": "2.0.3",
@@ -2999,13 +3073,15 @@
                       "dependencies": {
                         "cyclist": {
                           "version": "0.2.2",
-                          "bundled": true
+                          "bundled": true,
+                          "dev": true
                         }
                       }
                     },
                     "pump": {
                       "version": "1.0.3",
                       "bundled": true,
+                      "dev": true,
                       "requires": {
                         "end-of-stream": "1.4.1",
                         "once": "1.4.0"
@@ -3014,6 +3090,7 @@
                     "pumpify": {
                       "version": "1.4.0",
                       "bundled": true,
+                      "dev": true,
                       "requires": {
                         "duplexify": "3.5.4",
                         "inherits": "2.0.3",
@@ -3023,6 +3100,7 @@
                         "pump": {
                           "version": "2.0.1",
                           "bundled": true,
+                          "dev": true,
                           "requires": {
                             "end-of-stream": "1.4.1",
                             "once": "1.4.0"
@@ -3033,6 +3111,7 @@
                     "stream-each": {
                       "version": "1.2.2",
                       "bundled": true,
+                      "dev": true,
                       "requires": {
                         "end-of-stream": "1.4.1",
                         "stream-shift": "1.0.0"
@@ -3040,13 +3119,15 @@
                       "dependencies": {
                         "stream-shift": {
                           "version": "1.0.0",
-                          "bundled": true
+                          "bundled": true,
+                          "dev": true
                         }
                       }
                     },
                     "through2": {
                       "version": "2.0.3",
                       "bundled": true,
+                      "dev": true,
                       "requires": {
                         "readable-stream": "2.3.5",
                         "xtend": "4.0.1"
@@ -3054,7 +3135,8 @@
                       "dependencies": {
                         "xtend": {
                           "version": "4.0.1",
-                          "bundled": true
+                          "bundled": true,
+                          "dev": true
                         }
                       }
                     }
@@ -3063,6 +3145,7 @@
                 "node-fetch-npm": {
                   "version": "2.0.2",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "encoding": "0.1.12",
                     "json-parse-better-errors": "1.0.1",
@@ -3072,25 +3155,29 @@
                     "encoding": {
                       "version": "0.1.12",
                       "bundled": true,
+                      "dev": true,
                       "requires": {
                         "iconv-lite": "0.4.19"
                       },
                       "dependencies": {
                         "iconv-lite": {
                           "version": "0.4.19",
-                          "bundled": true
+                          "bundled": true,
+                          "dev": true
                         }
                       }
                     },
                     "json-parse-better-errors": {
                       "version": "1.0.1",
-                      "bundled": true
+                      "bundled": true,
+                      "dev": true
                     }
                   }
                 },
                 "socks-proxy-agent": {
                   "version": "3.0.1",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "agent-base": "4.2.0",
                     "socks": "1.1.10"
@@ -3099,6 +3186,7 @@
                     "agent-base": {
                       "version": "4.2.0",
                       "bundled": true,
+                      "dev": true,
                       "requires": {
                         "es6-promisify": "5.0.0"
                       },
@@ -3106,13 +3194,15 @@
                         "es6-promisify": {
                           "version": "5.0.0",
                           "bundled": true,
+                          "dev": true,
                           "requires": {
                             "es6-promise": "4.2.4"
                           },
                           "dependencies": {
                             "es6-promise": {
                               "version": "4.2.4",
-                              "bundled": true
+                              "bundled": true,
+                              "dev": true
                             }
                           }
                         }
@@ -3121,6 +3211,7 @@
                     "socks": {
                       "version": "1.1.10",
                       "bundled": true,
+                      "dev": true,
                       "requires": {
                         "ip": "1.1.5",
                         "smart-buffer": "1.1.15"
@@ -3128,11 +3219,13 @@
                       "dependencies": {
                         "ip": {
                           "version": "1.1.5",
-                          "bundled": true
+                          "bundled": true,
+                          "dev": true
                         },
                         "smart-buffer": {
                           "version": "1.1.15",
-                          "bundled": true
+                          "bundled": true,
+                          "dev": true
                         }
                       }
                     }
@@ -3143,6 +3236,7 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "brace-expansion": "1.1.11"
               },
@@ -3150,6 +3244,7 @@
                 "brace-expansion": {
                   "version": "1.1.11",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "balanced-match": "1.0.0",
                     "concat-map": "0.0.1"
@@ -3157,11 +3252,13 @@
                   "dependencies": {
                     "balanced-match": {
                       "version": "1.0.0",
-                      "bundled": true
+                      "bundled": true,
+                      "dev": true
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "bundled": true
+                      "bundled": true,
+                      "dev": true
                     }
                   }
                 }
@@ -3170,6 +3267,7 @@
             "npm-pick-manifest": {
               "version": "2.1.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "npm-package-arg": "6.0.0",
                 "semver": "5.5.0"
@@ -3178,6 +3276,7 @@
             "promise-retry": {
               "version": "1.1.1",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "err-code": "1.1.2",
                 "retry": "0.10.1"
@@ -3185,20 +3284,23 @@
               "dependencies": {
                 "err-code": {
                   "version": "1.1.2",
-                  "bundled": true
+                  "bundled": true,
+                  "dev": true
                 }
               }
             },
             "protoduck": {
               "version": "5.0.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "genfun": "4.0.1"
               },
               "dependencies": {
                 "genfun": {
                   "version": "4.0.1",
-                  "bundled": true
+                  "bundled": true,
+                  "dev": true
                 }
               }
             }
@@ -3206,19 +3308,23 @@
         },
         "path-is-inside": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "promise-inflight": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "qrcode-terminal": {
           "version": "0.11.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "query-string": {
           "version": "5.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "decode-uri-component": "0.2.0",
             "object-assign": "4.1.1",
@@ -3227,38 +3333,45 @@
           "dependencies": {
             "decode-uri-component": {
               "version": "0.2.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "object-assign": {
               "version": "4.1.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "strict-uri-encode": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "qw": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "read": {
           "version": "1.0.7",
           "bundled": true,
+          "dev": true,
           "requires": {
             "mute-stream": "0.0.7"
           },
           "dependencies": {
             "mute-stream": {
               "version": "0.0.7",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "read-cmd-shim": {
           "version": "1.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "graceful-fs": "4.1.11"
           }
@@ -3266,6 +3379,7 @@
         "read-installed": {
           "version": "4.0.3",
           "bundled": true,
+          "dev": true,
           "requires": {
             "debuglog": "1.0.1",
             "graceful-fs": "4.1.11",
@@ -3278,13 +3392,15 @@
           "dependencies": {
             "util-extend": {
               "version": "1.0.3",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "read-package-json": {
           "version": "2.0.13",
           "bundled": true,
+          "dev": true,
           "requires": {
             "glob": "7.1.2",
             "graceful-fs": "4.1.11",
@@ -3295,17 +3411,20 @@
           "dependencies": {
             "json-parse-better-errors": {
               "version": "1.0.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "slash": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "read-package-tree": {
           "version": "5.1.6",
           "bundled": true,
+          "dev": true,
           "requires": {
             "debuglog": "1.0.1",
             "dezalgo": "1.0.3",
@@ -3317,6 +3436,7 @@
         "readable-stream": {
           "version": "2.3.5",
           "bundled": true,
+          "dev": true,
           "requires": {
             "core-util-is": "1.0.2",
             "inherits": "2.0.3",
@@ -3329,32 +3449,38 @@
           "dependencies": {
             "core-util-is": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "isarray": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "process-nextick-args": {
               "version": "2.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "string_decoder": {
               "version": "1.0.3",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "safe-buffer": "5.1.1"
               }
             },
             "util-deprecate": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "readdir-scoped-modules": {
           "version": "1.0.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "debuglog": "1.0.1",
             "dezalgo": "1.0.3",
@@ -3365,6 +3491,7 @@
         "request": {
           "version": "2.83.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "aws-sign2": "0.7.0",
             "aws4": "1.6.0",
@@ -3392,40 +3519,48 @@
           "dependencies": {
             "aws-sign2": {
               "version": "0.7.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "aws4": {
               "version": "1.6.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "caseless": {
               "version": "0.12.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "combined-stream": {
               "version": "1.0.5",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "delayed-stream": "1.0.0"
               },
               "dependencies": {
                 "delayed-stream": {
                   "version": "1.0.0",
-                  "bundled": true
+                  "bundled": true,
+                  "dev": true
                 }
               }
             },
             "extend": {
               "version": "3.0.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "forever-agent": {
               "version": "0.6.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "form-data": {
               "version": "2.3.1",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "asynckit": "0.4.0",
                 "combined-stream": "1.0.5",
@@ -3434,13 +3569,15 @@
               "dependencies": {
                 "asynckit": {
                   "version": "0.4.0",
-                  "bundled": true
+                  "bundled": true,
+                  "dev": true
                 }
               }
             },
             "har-validator": {
               "version": "5.0.3",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "ajv": "5.2.3",
                 "har-schema": "2.0.0"
@@ -3449,6 +3586,7 @@
                 "ajv": {
                   "version": "5.2.3",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "co": "4.6.0",
                     "fast-deep-equal": "1.0.0",
@@ -3458,26 +3596,31 @@
                   "dependencies": {
                     "co": {
                       "version": "4.6.0",
-                      "bundled": true
+                      "bundled": true,
+                      "dev": true
                     },
                     "fast-deep-equal": {
                       "version": "1.0.0",
-                      "bundled": true
+                      "bundled": true,
+                      "dev": true
                     },
                     "json-schema-traverse": {
                       "version": "0.3.1",
-                      "bundled": true
+                      "bundled": true,
+                      "dev": true
                     },
                     "json-stable-stringify": {
                       "version": "1.0.1",
                       "bundled": true,
+                      "dev": true,
                       "requires": {
                         "jsonify": "0.0.0"
                       },
                       "dependencies": {
                         "jsonify": {
                           "version": "0.0.0",
-                          "bundled": true
+                          "bundled": true,
+                          "dev": true
                         }
                       }
                     }
@@ -3485,13 +3628,15 @@
                 },
                 "har-schema": {
                   "version": "2.0.0",
-                  "bundled": true
+                  "bundled": true,
+                  "dev": true
                 }
               }
             },
             "hawk": {
               "version": "6.0.2",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "boom": "4.3.1",
                 "cryptiles": "3.1.2",
@@ -3502,6 +3647,7 @@
                 "boom": {
                   "version": "4.3.1",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "hoek": "4.2.0"
                   }
@@ -3509,6 +3655,7 @@
                 "cryptiles": {
                   "version": "3.1.2",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "boom": "5.2.0"
                   },
@@ -3516,6 +3663,7 @@
                     "boom": {
                       "version": "5.2.0",
                       "bundled": true,
+                      "dev": true,
                       "requires": {
                         "hoek": "4.2.0"
                       }
@@ -3524,11 +3672,13 @@
                 },
                 "hoek": {
                   "version": "4.2.0",
-                  "bundled": true
+                  "bundled": true,
+                  "dev": true
                 },
                 "sntp": {
                   "version": "2.0.2",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "hoek": "4.2.0"
                   }
@@ -3538,6 +3688,7 @@
             "http-signature": {
               "version": "1.2.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "assert-plus": "1.0.0",
                 "jsprim": "1.4.1",
@@ -3546,11 +3697,13 @@
               "dependencies": {
                 "assert-plus": {
                   "version": "1.0.0",
-                  "bundled": true
+                  "bundled": true,
+                  "dev": true
                 },
                 "jsprim": {
                   "version": "1.4.1",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "assert-plus": "1.0.0",
                     "extsprintf": "1.3.0",
@@ -3560,15 +3713,18 @@
                   "dependencies": {
                     "extsprintf": {
                       "version": "1.3.0",
-                      "bundled": true
+                      "bundled": true,
+                      "dev": true
                     },
                     "json-schema": {
                       "version": "0.2.3",
-                      "bundled": true
+                      "bundled": true,
+                      "dev": true
                     },
                     "verror": {
                       "version": "1.10.0",
                       "bundled": true,
+                      "dev": true,
                       "requires": {
                         "assert-plus": "1.0.0",
                         "core-util-is": "1.0.2",
@@ -3577,7 +3733,8 @@
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
-                          "bundled": true
+                          "bundled": true,
+                          "dev": true
                         }
                       }
                     }
@@ -3586,6 +3743,7 @@
                 "sshpk": {
                   "version": "1.13.1",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "asn1": "0.2.3",
                     "assert-plus": "1.0.0",
@@ -3599,11 +3757,13 @@
                   "dependencies": {
                     "asn1": {
                       "version": "0.2.3",
-                      "bundled": true
+                      "bundled": true,
+                      "dev": true
                     },
                     "bcrypt-pbkdf": {
                       "version": "1.0.1",
                       "bundled": true,
+                      "dev": true,
                       "optional": true,
                       "requires": {
                         "tweetnacl": "0.14.5"
@@ -3612,6 +3772,7 @@
                     "dashdash": {
                       "version": "1.14.1",
                       "bundled": true,
+                      "dev": true,
                       "requires": {
                         "assert-plus": "1.0.0"
                       }
@@ -3619,6 +3780,7 @@
                     "ecc-jsbn": {
                       "version": "0.1.1",
                       "bundled": true,
+                      "dev": true,
                       "optional": true,
                       "requires": {
                         "jsbn": "0.1.1"
@@ -3627,6 +3789,7 @@
                     "getpass": {
                       "version": "0.1.7",
                       "bundled": true,
+                      "dev": true,
                       "requires": {
                         "assert-plus": "1.0.0"
                       }
@@ -3634,11 +3797,13 @@
                     "jsbn": {
                       "version": "0.1.1",
                       "bundled": true,
+                      "dev": true,
                       "optional": true
                     },
                     "tweetnacl": {
                       "version": "0.14.5",
                       "bundled": true,
+                      "dev": true,
                       "optional": true
                     }
                   }
@@ -3647,61 +3812,73 @@
             },
             "is-typedarray": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "isstream": {
               "version": "0.1.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "json-stringify-safe": {
               "version": "5.0.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "mime-types": {
               "version": "2.1.17",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "mime-db": "1.30.0"
               },
               "dependencies": {
                 "mime-db": {
                   "version": "1.30.0",
-                  "bundled": true
+                  "bundled": true,
+                  "dev": true
                 }
               }
             },
             "oauth-sign": {
               "version": "0.8.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "performance-now": {
               "version": "2.1.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "qs": {
               "version": "6.5.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "stringstream": {
               "version": "0.0.5",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "tough-cookie": {
               "version": "2.3.3",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "punycode": "1.4.1"
               },
               "dependencies": {
                 "punycode": {
                   "version": "1.4.1",
-                  "bundled": true
+                  "bundled": true,
+                  "dev": true
                 }
               }
             },
             "tunnel-agent": {
               "version": "0.6.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "safe-buffer": "5.1.1"
               }
@@ -3710,26 +3887,31 @@
         },
         "retry": {
           "version": "0.10.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "rimraf": {
           "version": "2.6.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "glob": "7.1.2"
           }
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "semver": {
           "version": "5.5.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "sha": {
           "version": "2.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
             "readable-stream": "2.3.5"
@@ -3737,15 +3919,18 @@
         },
         "slide": {
           "version": "1.1.6",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "sorted-object": {
           "version": "2.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "sorted-union-stream": {
           "version": "2.1.3",
           "bundled": true,
+          "dev": true,
           "requires": {
             "from2": "1.3.0",
             "stream-iterate": "1.2.0"
@@ -3754,6 +3939,7 @@
             "from2": {
               "version": "1.3.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "inherits": "2.0.3",
                 "readable-stream": "1.1.14"
@@ -3762,6 +3948,7 @@
                 "readable-stream": {
                   "version": "1.1.14",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "core-util-is": "1.0.2",
                     "inherits": "2.0.3",
@@ -3771,15 +3958,18 @@
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
-                      "bundled": true
+                      "bundled": true,
+                      "dev": true
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "bundled": true
+                      "bundled": true,
+                      "dev": true
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "bundled": true
+                      "bundled": true,
+                      "dev": true
                     }
                   }
                 }
@@ -3788,6 +3978,7 @@
             "stream-iterate": {
               "version": "1.2.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "readable-stream": "2.3.5",
                 "stream-shift": "1.0.0"
@@ -3795,7 +3986,8 @@
               "dependencies": {
                 "stream-shift": {
                   "version": "1.0.0",
-                  "bundled": true
+                  "bundled": true,
+                  "dev": true
                 }
               }
             }
@@ -3804,6 +3996,7 @@
         "ssri": {
           "version": "5.2.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "safe-buffer": "5.1.1"
           }
@@ -3811,19 +4004,22 @@
         "strip-ansi": {
           "version": "4.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "ansi-regex": "3.0.0"
           },
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "tar": {
           "version": "4.4.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "chownr": "1.0.1",
             "fs-minipass": "1.2.5",
@@ -3836,6 +4032,7 @@
             "fs-minipass": {
               "version": "1.2.5",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "minipass": "2.2.1"
               }
@@ -3843,6 +4040,7 @@
             "minipass": {
               "version": "2.2.1",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "yallist": "3.0.2"
               }
@@ -3850,31 +4048,37 @@
             "minizlib": {
               "version": "1.1.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "minipass": "2.2.1"
               }
             },
             "yallist": {
               "version": "3.0.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "text-table": {
           "version": "0.2.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "uid-number": {
           "version": "0.0.6",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "umask": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "unique-filename": {
           "version": "1.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "unique-slug": "2.0.0"
           },
@@ -3882,6 +4086,7 @@
             "unique-slug": {
               "version": "2.0.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "imurmurhash": "0.1.4"
               }
@@ -3890,11 +4095,13 @@
         },
         "unpipe": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "update-notifier": {
           "version": "2.3.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "boxen": "1.2.1",
             "chalk": "2.1.0",
@@ -3910,6 +4117,7 @@
             "boxen": {
               "version": "1.2.1",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "ansi-align": "2.0.0",
                 "camelcase": "4.1.0",
@@ -3923,21 +4131,25 @@
                 "ansi-align": {
                   "version": "2.0.0",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "string-width": "2.1.1"
                   }
                 },
                 "camelcase": {
                   "version": "4.1.0",
-                  "bundled": true
+                  "bundled": true,
+                  "dev": true
                 },
                 "cli-boxes": {
                   "version": "1.0.0",
-                  "bundled": true
+                  "bundled": true,
+                  "dev": true
                 },
                 "string-width": {
                   "version": "2.1.1",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "is-fullwidth-code-point": "2.0.0",
                     "strip-ansi": "4.0.0"
@@ -3945,13 +4157,15 @@
                   "dependencies": {
                     "is-fullwidth-code-point": {
                       "version": "2.0.0",
-                      "bundled": true
+                      "bundled": true,
+                      "dev": true
                     }
                   }
                 },
                 "term-size": {
                   "version": "1.2.0",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "execa": "0.7.0"
                   },
@@ -3959,6 +4173,7 @@
                     "execa": {
                       "version": "0.7.0",
                       "bundled": true,
+                      "dev": true,
                       "requires": {
                         "cross-spawn": "5.1.0",
                         "get-stream": "3.0.0",
@@ -3972,6 +4187,7 @@
                         "cross-spawn": {
                           "version": "5.1.0",
                           "bundled": true,
+                          "dev": true,
                           "requires": {
                             "lru-cache": "4.1.1",
                             "shebang-command": "1.2.0",
@@ -3981,13 +4197,15 @@
                             "shebang-command": {
                               "version": "1.2.0",
                               "bundled": true,
+                              "dev": true,
                               "requires": {
                                 "shebang-regex": "1.0.0"
                               },
                               "dependencies": {
                                 "shebang-regex": {
                                   "version": "1.0.0",
-                                  "bundled": true
+                                  "bundled": true,
+                                  "dev": true
                                 }
                               }
                             }
@@ -3995,36 +4213,43 @@
                         },
                         "get-stream": {
                           "version": "3.0.0",
-                          "bundled": true
+                          "bundled": true,
+                          "dev": true
                         },
                         "is-stream": {
                           "version": "1.1.0",
-                          "bundled": true
+                          "bundled": true,
+                          "dev": true
                         },
                         "npm-run-path": {
                           "version": "2.0.2",
                           "bundled": true,
+                          "dev": true,
                           "requires": {
                             "path-key": "2.0.1"
                           },
                           "dependencies": {
                             "path-key": {
                               "version": "2.0.1",
-                              "bundled": true
+                              "bundled": true,
+                              "dev": true
                             }
                           }
                         },
                         "p-finally": {
                           "version": "1.0.0",
-                          "bundled": true
+                          "bundled": true,
+                          "dev": true
                         },
                         "signal-exit": {
                           "version": "3.0.2",
-                          "bundled": true
+                          "bundled": true,
+                          "dev": true
                         },
                         "strip-eof": {
                           "version": "1.0.0",
-                          "bundled": true
+                          "bundled": true,
+                          "dev": true
                         }
                       }
                     }
@@ -4033,6 +4258,7 @@
                 "widest-line": {
                   "version": "1.0.0",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "string-width": "1.0.2"
                   },
@@ -4040,6 +4266,7 @@
                     "string-width": {
                       "version": "1.0.2",
                       "bundled": true,
+                      "dev": true,
                       "requires": {
                         "code-point-at": "1.1.0",
                         "is-fullwidth-code-point": "1.0.0",
@@ -4048,31 +4275,36 @@
                       "dependencies": {
                         "code-point-at": {
                           "version": "1.1.0",
-                          "bundled": true
+                          "bundled": true,
+                          "dev": true
                         },
                         "is-fullwidth-code-point": {
                           "version": "1.0.0",
                           "bundled": true,
+                          "dev": true,
                           "requires": {
                             "number-is-nan": "1.0.1"
                           },
                           "dependencies": {
                             "number-is-nan": {
                               "version": "1.0.1",
-                              "bundled": true
+                              "bundled": true,
+                              "dev": true
                             }
                           }
                         },
                         "strip-ansi": {
                           "version": "3.0.1",
                           "bundled": true,
+                          "dev": true,
                           "requires": {
                             "ansi-regex": "2.1.1"
                           },
                           "dependencies": {
                             "ansi-regex": {
                               "version": "2.1.1",
-                              "bundled": true
+                              "bundled": true,
+                              "dev": true
                             }
                           }
                         }
@@ -4085,6 +4317,7 @@
             "chalk": {
               "version": "2.1.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "ansi-styles": "3.2.0",
                 "escape-string-regexp": "1.0.5",
@@ -4094,6 +4327,7 @@
                 "ansi-styles": {
                   "version": "3.2.0",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "color-convert": "1.9.0"
                   },
@@ -4101,13 +4335,15 @@
                     "color-convert": {
                       "version": "1.9.0",
                       "bundled": true,
+                      "dev": true,
                       "requires": {
                         "color-name": "1.1.3"
                       },
                       "dependencies": {
                         "color-name": {
                           "version": "1.1.3",
-                          "bundled": true
+                          "bundled": true,
+                          "dev": true
                         }
                       }
                     }
@@ -4115,18 +4351,21 @@
                 },
                 "escape-string-regexp": {
                   "version": "1.0.5",
-                  "bundled": true
+                  "bundled": true,
+                  "dev": true
                 },
                 "supports-color": {
                   "version": "4.4.0",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "has-flag": "2.0.0"
                   },
                   "dependencies": {
                     "has-flag": {
                       "version": "2.0.0",
-                      "bundled": true
+                      "bundled": true,
+                      "dev": true
                     }
                   }
                 }
@@ -4135,6 +4374,7 @@
             "configstore": {
               "version": "3.1.1",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "dot-prop": "4.2.0",
                 "graceful-fs": "4.1.11",
@@ -4147,39 +4387,45 @@
                 "dot-prop": {
                   "version": "4.2.0",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "is-obj": "1.0.1"
                   },
                   "dependencies": {
                     "is-obj": {
                       "version": "1.0.1",
-                      "bundled": true
+                      "bundled": true,
+                      "dev": true
                     }
                   }
                 },
                 "make-dir": {
                   "version": "1.0.0",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "pify": "2.3.0"
                   },
                   "dependencies": {
                     "pify": {
                       "version": "2.3.0",
-                      "bundled": true
+                      "bundled": true,
+                      "dev": true
                     }
                   }
                 },
                 "unique-string": {
                   "version": "1.0.0",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "crypto-random-string": "1.0.0"
                   },
                   "dependencies": {
                     "crypto-random-string": {
                       "version": "1.0.0",
-                      "bundled": true
+                      "bundled": true,
+                      "dev": true
                     }
                   }
                 }
@@ -4187,11 +4433,13 @@
             },
             "import-lazy": {
               "version": "2.1.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "is-installed-globally": {
               "version": "0.1.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "global-dirs": "0.1.0",
                 "is-path-inside": "1.0.0"
@@ -4200,6 +4448,7 @@
                 "global-dirs": {
                   "version": "0.1.0",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "ini": "1.3.5"
                   }
@@ -4207,6 +4456,7 @@
                 "is-path-inside": {
                   "version": "1.0.0",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "path-is-inside": "1.0.2"
                   }
@@ -4215,11 +4465,13 @@
             },
             "is-npm": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "latest-version": {
               "version": "3.1.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "package-json": "4.0.1"
               },
@@ -4227,6 +4479,7 @@
                 "package-json": {
                   "version": "4.0.1",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "got": "6.7.1",
                     "registry-auth-token": "3.3.1",
@@ -4237,6 +4490,7 @@
                     "got": {
                       "version": "6.7.1",
                       "bundled": true,
+                      "dev": true,
                       "requires": {
                         "create-error-class": "3.0.2",
                         "duplexer3": "0.1.4",
@@ -4254,58 +4508,70 @@
                         "create-error-class": {
                           "version": "3.0.2",
                           "bundled": true,
+                          "dev": true,
                           "requires": {
                             "capture-stack-trace": "1.0.0"
                           },
                           "dependencies": {
                             "capture-stack-trace": {
                               "version": "1.0.0",
-                              "bundled": true
+                              "bundled": true,
+                              "dev": true
                             }
                           }
                         },
                         "duplexer3": {
                           "version": "0.1.4",
-                          "bundled": true
+                          "bundled": true,
+                          "dev": true
                         },
                         "get-stream": {
                           "version": "3.0.0",
-                          "bundled": true
+                          "bundled": true,
+                          "dev": true
                         },
                         "is-redirect": {
                           "version": "1.0.0",
-                          "bundled": true
+                          "bundled": true,
+                          "dev": true
                         },
                         "is-retry-allowed": {
                           "version": "1.1.0",
-                          "bundled": true
+                          "bundled": true,
+                          "dev": true
                         },
                         "is-stream": {
                           "version": "1.1.0",
-                          "bundled": true
+                          "bundled": true,
+                          "dev": true
                         },
                         "lowercase-keys": {
                           "version": "1.0.0",
-                          "bundled": true
+                          "bundled": true,
+                          "dev": true
                         },
                         "timed-out": {
                           "version": "4.0.1",
-                          "bundled": true
+                          "bundled": true,
+                          "dev": true
                         },
                         "unzip-response": {
                           "version": "2.0.1",
-                          "bundled": true
+                          "bundled": true,
+                          "dev": true
                         },
                         "url-parse-lax": {
                           "version": "1.0.0",
                           "bundled": true,
+                          "dev": true,
                           "requires": {
                             "prepend-http": "1.0.4"
                           },
                           "dependencies": {
                             "prepend-http": {
                               "version": "1.0.4",
-                              "bundled": true
+                              "bundled": true,
+                              "dev": true
                             }
                           }
                         }
@@ -4314,6 +4580,7 @@
                     "registry-auth-token": {
                       "version": "3.3.1",
                       "bundled": true,
+                      "dev": true,
                       "requires": {
                         "rc": "1.2.1",
                         "safe-buffer": "5.1.1"
@@ -4322,6 +4589,7 @@
                         "rc": {
                           "version": "1.2.1",
                           "bundled": true,
+                          "dev": true,
                           "requires": {
                             "deep-extend": "0.4.2",
                             "ini": "1.3.5",
@@ -4331,15 +4599,18 @@
                           "dependencies": {
                             "deep-extend": {
                               "version": "0.4.2",
-                              "bundled": true
+                              "bundled": true,
+                              "dev": true
                             },
                             "minimist": {
                               "version": "1.2.0",
-                              "bundled": true
+                              "bundled": true,
+                              "dev": true
                             },
                             "strip-json-comments": {
                               "version": "2.0.1",
-                              "bundled": true
+                              "bundled": true,
+                              "dev": true
                             }
                           }
                         }
@@ -4348,6 +4619,7 @@
                     "registry-url": {
                       "version": "3.1.0",
                       "bundled": true,
+                      "dev": true,
                       "requires": {
                         "rc": "1.2.1"
                       },
@@ -4355,6 +4627,7 @@
                         "rc": {
                           "version": "1.2.1",
                           "bundled": true,
+                          "dev": true,
                           "requires": {
                             "deep-extend": "0.4.2",
                             "ini": "1.3.5",
@@ -4364,15 +4637,18 @@
                           "dependencies": {
                             "deep-extend": {
                               "version": "0.4.2",
-                              "bundled": true
+                              "bundled": true,
+                              "dev": true
                             },
                             "minimist": {
                               "version": "1.2.0",
-                              "bundled": true
+                              "bundled": true,
+                              "dev": true
                             },
                             "strip-json-comments": {
                               "version": "2.0.1",
-                              "bundled": true
+                              "bundled": true,
+                              "dev": true
                             }
                           }
                         }
@@ -4385,23 +4661,27 @@
             "semver-diff": {
               "version": "2.1.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "semver": "5.5.0"
               }
             },
             "xdg-basedir": {
               "version": "3.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "uuid": {
           "version": "3.2.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "validate-npm-package-license": {
           "version": "3.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "spdx-correct": "1.0.2",
             "spdx-expression-parse": "1.0.4"
@@ -4410,51 +4690,59 @@
             "spdx-correct": {
               "version": "1.0.2",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "spdx-license-ids": "1.2.2"
               },
               "dependencies": {
                 "spdx-license-ids": {
                   "version": "1.2.2",
-                  "bundled": true
+                  "bundled": true,
+                  "dev": true
                 }
               }
             },
             "spdx-expression-parse": {
               "version": "1.0.4",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "validate-npm-package-name": {
           "version": "3.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "builtins": "1.0.3"
           },
           "dependencies": {
             "builtins": {
               "version": "1.0.3",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "which": {
           "version": "1.3.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "isexe": "2.0.0"
           },
           "dependencies": {
             "isexe": {
               "version": "2.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "worker-farm": {
           "version": "1.5.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "errno": "0.1.7",
             "xtend": "4.0.1"
@@ -4463,29 +4751,34 @@
             "errno": {
               "version": "0.1.7",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "prr": "1.0.1"
               },
               "dependencies": {
                 "prr": {
                   "version": "1.0.1",
-                  "bundled": true
+                  "bundled": true,
+                  "dev": true
                 }
               }
             },
             "xtend": {
               "version": "4.0.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "write-file-atomic": {
           "version": "2.3.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
             "imurmurhash": "0.1.4",
@@ -4494,10 +4787,25 @@
           "dependencies": {
             "signal-exit": {
               "version": "3.0.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         }
+      }
+    },
+    "npm-bundled": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.3.tgz",
+      "integrity": "sha512-ByQ3oJ/5ETLyglU2+8dBObvhfWXX8dtPZDMePCahptliFX2iIuhyEszyFk401PZUNQH20vvdW5MLjJxkwU80Ow=="
+    },
+    "npm-packlist": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.1.10.tgz",
+      "integrity": "sha512-AQC0Dyhzn4EiYEfIUjCdMl0JJ61I2ER9ukf/sLxJUcZHfo+VyEfz2rMJgLZSS1v30OxPQe1cN0LZA1xbcaVfWA==",
+      "requires": {
+        "ignore-walk": "3.0.1",
+        "npm-bundled": "1.0.3"
       }
     },
     "npmlog": {
@@ -4515,11 +4823,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
-    },
-    "oauth-sign": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
     },
     "object-assign": {
       "version": "4.1.1",
@@ -4545,9 +4848,9 @@
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "osenv": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
-      "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
       "requires": {
         "os-homedir": "1.0.2",
         "os-tmpdir": "1.0.2"
@@ -4558,33 +4861,18 @@
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
-    "performance-now": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-      "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
-    },
     "process-nextick-args": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
-    },
-    "punycode": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
-    },
-    "qs": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-      "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
     },
     "rc": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
-      "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.6.tgz",
+      "integrity": "sha1-6xiYnG1PTxYsOZ953dKfODVWgJI=",
       "requires": {
         "deep-extend": "0.4.2",
-        "ini": "1.3.4",
+        "ini": "1.3.5",
         "minimist": "1.2.0",
         "strip-json-comments": "2.0.1"
       },
@@ -4597,46 +4885,17 @@
       }
     },
     "readable-stream": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-      "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
         "core-util-is": "1.0.2",
         "inherits": "2.0.3",
         "isarray": "1.0.0",
-        "process-nextick-args": "1.0.7",
-        "safe-buffer": "5.1.1",
-        "string_decoder": "1.0.3",
+        "process-nextick-args": "2.0.0",
+        "safe-buffer": "5.1.2",
+        "string_decoder": "1.1.1",
         "util-deprecate": "1.0.2"
-      }
-    },
-    "request": {
-      "version": "2.81.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-      "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
-      "requires": {
-        "aws-sign2": "0.6.0",
-        "aws4": "1.6.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.5",
-        "extend": "3.0.1",
-        "forever-agent": "0.6.1",
-        "form-data": "2.1.4",
-        "har-validator": "4.2.1",
-        "hawk": "3.1.3",
-        "http-signature": "1.1.1",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.17",
-        "oauth-sign": "0.8.2",
-        "performance-now": "0.2.0",
-        "qs": "6.4.0",
-        "safe-buffer": "5.1.1",
-        "stringstream": "0.0.5",
-        "tough-cookie": "2.3.3",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.1.0"
       }
     },
     "rimraf": {
@@ -4648,20 +4907,24 @@
       }
     },
     "safe-buffer": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sax": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-0.4.2.tgz",
-      "integrity": "sha1-OfO2AXM9a+yXEFskKipA/Wl4rDw=",
-      "dev": true
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "semver": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha1-4FnAnYVx8FQII3M0M1BdOi8AsY4="
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
     },
     "set-blocking": {
       "version": "2.0.0",
@@ -4679,36 +4942,6 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
-    "sntp": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-      "requires": {
-        "hoek": "2.16.3"
-      }
-    },
-    "sshpk": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
-      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
-      "requires": {
-        "asn1": "0.2.3",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.1",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.1",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "tweetnacl": "0.14.5"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-        }
-      }
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -4720,17 +4953,12 @@
       }
     },
     "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "5.1.2"
       }
-    },
-    "stringstream": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
     },
     "strip-ansi": {
       "version": "3.0.1",
@@ -4752,28 +4980,17 @@
       "dev": true
     },
     "tar": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-      "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.1.tgz",
+      "integrity": "sha512-O+v1r9yN4tOsvl90p5HAP4AEqbYhx4036AGMm075fH9F8Qwi3oJ+v4u50FkT/KkvywNGtwkk0zRI+8eYm1X/xg==",
       "requires": {
-        "block-stream": "0.0.9",
-        "fstream": "1.0.11",
-        "inherits": "2.0.3"
-      }
-    },
-    "tar-pack": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz",
-      "integrity": "sha1-I74tf2cagzk3bL2wuP4/3r8xeYQ=",
-      "requires": {
-        "debug": "2.6.9",
-        "fstream": "1.0.11",
-        "fstream-ignore": "1.0.5",
-        "once": "1.4.0",
-        "readable-stream": "2.3.3",
-        "rimraf": "2.6.2",
-        "tar": "2.2.1",
-        "uid-number": "0.0.6"
+        "chownr": "1.0.1",
+        "fs-minipass": "1.2.5",
+        "minipass": "2.2.4",
+        "minizlib": "1.1.0",
+        "mkdirp": "0.5.1",
+        "safe-buffer": "5.1.2",
+        "yallist": "3.0.2"
       }
     },
     "to-iso-string": {
@@ -4782,65 +4999,16 @@
       "integrity": "sha1-TcGeZk38y+Jb2NtQiwDG2hWCVdE=",
       "dev": true
     },
-    "tough-cookie": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
-      "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
-      "requires": {
-        "punycode": "1.4.1"
-      }
-    },
-    "tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
-    "tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "optional": true
-    },
     "type-detect": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
       "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
       "dev": true
     },
-    "uid-number": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
-      "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE="
-    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-    },
-    "uuid": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-      "integrity": "sha1-PdPT55Crwk17DToDT/q6vijrvAQ="
-    },
-    "verror": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "requires": {
-        "assert-plus": "1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-        }
-      }
     },
     "wide-align": {
       "version": "1.1.2",
@@ -4862,6 +5030,14 @@
       "dev": true,
       "requires": {
         "sax": "0.4.2"
+      },
+      "dependencies": {
+        "sax": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/sax/-/sax-0.4.2.tgz",
+          "integrity": "sha1-OfO2AXM9a+yXEFskKipA/Wl4rDw=",
+          "dev": true
+        }
       }
     },
     "xmlbuilder": {
@@ -4869,6 +5045,11 @@
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-0.4.2.tgz",
       "integrity": "sha1-F3bWXz/brUcKCNhgTN6xxOVA/4M=",
       "dev": true
+    },
+    "yallist": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
+      "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hummus",
-  "version": "1.0.86",
+  "version": "1.0.87",
   "description": "Create, read and modify PDF files and streams",
   "homepage": "http://pdfhummus.com/",
   "license": "Apache-2.0",
@@ -28,8 +28,7 @@
     "PDFRStreamForBuffer.js"
   ],
   "dependencies": {
-    "node-pre-gyp": "^0.6.13",
-    "npm": "^5.8.0"
+    "node-pre-gyp": "^0.9.1"
   },
   "bundledDependencies": [
     "node-pre-gyp"
@@ -37,7 +36,8 @@
   "devDependencies": {
     "aws-sdk": "~2.0.0-rc.15",
     "chai": "^3.4.0",
-    "mocha": "^2.3.3"
+    "mocha": "^2.3.3",
+    "npm": "^5.8.0"
   },
   "binary": {
     "module_name": "hummus",


### PR DESCRIPTION
NSP (https://www.npmjs.com/package/nsp) is flagging this module as vulnerable due to the dependency on hoek (https://github.com/hapijs/hoek) via node-pre-gyp@0.6.38 and npm@5.8.0:

![screen shot 2018-04-27 at 9 51 48 am](https://user-images.githubusercontent.com/14101642/39368271-246fe37a-4a07-11e8-904f-1e6f9cd23ba2.png)

Currently there is an explicit dependency on node-pre-gyp@0.6.39, this vulnerability can be solved by upgrading this dependency to 0.9.1.
For npm I think it is safe to move that dependency as a devDependency, this way NSP won’t complain about security vulnerabilities there.  