### PR TITLE
Support musl based binaries

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "module_path": "./binding",
     "remote_path": "./{module_name}/v{version}/{toolset}/",
     "host": "https://hummus.s3-us-west-2.amazonaws.com",
-    "package_name": "{node_abi}-{platform}-{arch}.tar.gz"
+    "package_name": "{node_abi}-{platform}-{arch}-{libc}.tar.gz"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"


### PR DESCRIPTION
Can you support musl libc? The current uploaded libraries is based on glibc. So I can not use your fantastic library on alpine.

#230 
#111 

I am not sure how to make musl libc based binary on travisci. If you know, please help me.