### PR TITLE
Publish musl builds for Alpine Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,13 +77,14 @@ script:
   ./node_modules/.bin/node-pre-gyp package testpackage $EXTRA_NODE_PRE_GYP_FLAGS;
   npm test;
   fi
-- if [[ "${PUBLISH_BINARY}" ]]; then
+- if [[ "${PUBLISH_BINARY}" == "true" ]]; then
   ./node_modules/.bin/node-pre-gyp unpublish publish $EXTRA_NODE_PRE_GYP_FLAGS; 
   rm -rf {build,binding};
   fi
-- if [[ $MUSL ]]; then 
+- if [[ "${PUBLISH_BINARY}" == "true" && "{$MUSL}" == "true" ]]; then 
   ./scripts/alpine-test.sh ./node_modules/.bin/node-pre-gyp install $EXTRA_NODE_PRE_GYP_FLAGS;
-  else
+  fi
+- if [[ "{PUBLISH_BINARY}" == "true" && "${MUSL}" != "true" ]]; then
   ./node_modules/.bin/node-pre-gyp install $EXTRA_NODE_PRE_GYP_FLAGS;
   npm test;
   fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,12 @@ matrix:
   allow_failures:
   - env: ELECTRON_VERSION="3.0.10" NODE_NVM_VERSION="10.2.0"
   - os: osx
-    env: MUSL=true
+    env: MUSL=true NODE_NVM_VERSION="9.11.1"
+  - os: osx
+    env: MUSL=true NODE_NVM_VERSION="10.8.0"
+  - os: osx
+    env: MUSL=true NODE_NVM_VERSION="11.2.0"
+
 before_install:
 - if [[ $TRAVIS_OS_NAME == "linux" ]]; then export CXX=g++-4.8; fi
 - if [[ $ELECTRON_VERSION ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ addons:
     - ubuntu-toolchain-r-test
     packages:
     - g++-4.8
+services:
+    - docker
 env:
   matrix:
   - NODE_NVM_VERSION="4.9.1"
@@ -32,6 +34,8 @@ env:
 matrix:
   allow_failures:
   - env: ELECTRON_VERSION="3.0.10" NODE_NVM_VERSION="10.2.0"
+  - os: osx
+    env: MUSL=true
 before_install:
 - if [[ $TRAVIS_OS_NAME == "linux" ]]; then export CXX=g++-4.8; fi
 - if [[ $ELECTRON_VERSION ]]; then
@@ -56,10 +60,28 @@ before_install:
 - npm --version
 - $CXX --version
 install:
-- npm install --build-from-source
+- if [[ $MUSL ]]; then
+  scripts/alpine-build.sh;
+  fi
+- if [[ $MUSL != "true" ]]; then
+  npm install --build-from-source;
+  fi
 script:
-- ./node_modules/.bin/node-pre-gyp package testpackage $EXTRA_NODE_PRE_GYP_FLAGS
-- npm test
-- if [[ "${PUBLISH_BINARY}" == "true" ]]; then ./node_modules/.bin/node-pre-gyp unpublish
-  publish $EXTRA_NODE_PRE_GYP_FLAGS; rm -rf {build,binding}; ./node_modules/.bin/node-pre-gyp install $EXTRA_NODE_PRE_GYP_FLAGS; npm test;
+- if [[ $MUSL ]]; then
+  scripts/alpine-test.sh;
+  fi
+- if [[ $MUSL != "true" ]]; then
+  ./node_modules/.bin/node-pre-gyp package testpackage $EXTRA_NODE_PRE_GYP_FLAGS;
+  npm test;
+  fi
+- if [[ "${PUBLISH_BINARY}" == "true" && "${MUSL}" != "true" ]]; then 
+  ./node_modules/.bin/node-pre-gyp unpublish publish $EXTRA_NODE_PRE_GYP_FLAGS; 
+  rm -rf {build,binding};
+  ./node_modules/.bin/node-pre-gyp install $EXTRA_NODE_PRE_GYP_FLAGS;
+  npm test;
+  fi
+- if [[ "${PUBLISH_BINARY}" == "true" && "${MUSL}" == "true" ]]; then 
+  ./node_modules/.bin/node-pre-gyp unpublish publish $EXTRA_NODE_PRE_GYP_FLAGS; 
+  rm -rf {build,binding};
+  ./scripts/alpine-final-test.sh;
   fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,8 +67,7 @@ before_install:
 install:
 - if [[ $MUSL ]]; then
   scripts/alpine-build.sh;
-  fi
-- if [[ $MUSL != "true" ]]; then
+  else
   npm install --build-from-source;
   fi
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,20 +73,20 @@ install:
   fi
 script:
 - if [[ $MUSL ]]; then
-  scripts/alpine-test.sh;
+  scripts/alpine-test.sh ./node_modules/.bin/node-pre-gyp package testpackage $EXTRA_NODE_PRE_GYP_FLAGS;
   fi
 - if [[ $MUSL != "true" ]]; then
   ./node_modules/.bin/node-pre-gyp package testpackage $EXTRA_NODE_PRE_GYP_FLAGS;
   npm test;
   fi
-- if [[ "${PUBLISH_BINARY}" == "true" && "${MUSL}" != "true" ]]; then 
+- if [[ "${PUBLISH_BINARY}" ]]; then
   ./node_modules/.bin/node-pre-gyp unpublish publish $EXTRA_NODE_PRE_GYP_FLAGS; 
   rm -rf {build,binding};
+  fi
+- if [[ "${MUSL}" != "true" ]]; then
   ./node_modules/.bin/node-pre-gyp install $EXTRA_NODE_PRE_GYP_FLAGS;
   npm test;
   fi
-- if [[ "${PUBLISH_BINARY}" == "true" && "${MUSL}" == "true" ]]; then 
-  ./node_modules/.bin/node-pre-gyp unpublish publish $EXTRA_NODE_PRE_GYP_FLAGS; 
-  rm -rf {build,binding};
-  ./scripts/alpine-final-test.sh;
+- if [[ $MUSL ]]; then 
+  ./scripts/alpine-test.sh ./node_modules/.bin/node-pre-gyp install $EXTRA_NODE_PRE_GYP_FLAGS;
   fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,8 +74,7 @@ install:
 script:
 - if [[ $MUSL ]]; then
   scripts/alpine-test.sh ./node_modules/.bin/node-pre-gyp package testpackage $EXTRA_NODE_PRE_GYP_FLAGS;
-  fi
-- if [[ $MUSL != "true" ]]; then
+  else
   ./node_modules/.bin/node-pre-gyp package testpackage $EXTRA_NODE_PRE_GYP_FLAGS;
   npm test;
   fi
@@ -83,10 +82,9 @@ script:
   ./node_modules/.bin/node-pre-gyp unpublish publish $EXTRA_NODE_PRE_GYP_FLAGS; 
   rm -rf {build,binding};
   fi
-- if [[ "${MUSL}" != "true" ]]; then
-  ./node_modules/.bin/node-pre-gyp install $EXTRA_NODE_PRE_GYP_FLAGS;
-  npm test;
-  fi
 - if [[ $MUSL ]]; then 
   ./scripts/alpine-test.sh ./node_modules/.bin/node-pre-gyp install $EXTRA_NODE_PRE_GYP_FLAGS;
+  else
+  ./node_modules/.bin/node-pre-gyp install $EXTRA_NODE_PRE_GYP_FLAGS;
+  npm test;
   fi

--- a/scripts/alpine-build.sh
+++ b/scripts/alpine-build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+docker run -v ${PWD}:/build -i node:${NODE_NVM_VERSION}-alpine /bin/sh <<-EOF
+apk add --no-cache make gcc jq g++ python
+cd /build
+EXTRA_NODE_PRE_GYP_FLAGS="--target_libc=musl" npm install --build-from-source --unsafe-perm
+EOF
+sudo chown -R travis ${PWD}

--- a/scripts/alpine-final-test.sh
+++ b/scripts/alpine-final-test.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+docker run -v ${PWD}:/build -i node:${NODE_NVM_VERSION}-alpine /bin/sh <<-EOF
+cd /build
+./node_modules/.bin/node-pre-gyp install $EXTRA_NODE_PRE_GYP_FLAGS
+npm test
+EOF
+sudo chown -R travis ${PWD}

--- a/scripts/alpine-final-test.sh
+++ b/scripts/alpine-final-test.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-docker run -v ${PWD}:/build -i node:${NODE_NVM_VERSION}-alpine /bin/sh <<-EOF
-cd /build
-./node_modules/.bin/node-pre-gyp install $EXTRA_NODE_PRE_GYP_FLAGS
-npm test
-EOF
-sudo chown -R travis ${PWD}

--- a/scripts/alpine-test.sh
+++ b/scripts/alpine-test.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+docker run -v ${PWD}:/build -i node:${NODE_NVM_VERSION}-alpine /bin/sh <<-EOF
+cd /build
+npm test
+EOF
+sudo chown -R travis ${PWD}

--- a/scripts/alpine-test.sh
+++ b/scripts/alpine-test.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 docker run -v ${PWD}:/build -i node:${NODE_NVM_VERSION}-alpine /bin/sh <<-EOF
 cd /build
+$*
 npm test
 EOF
 sudo chown -R travis ${PWD}


### PR DESCRIPTION
It appears the current musl binaries that node-pre-gyp installs are actually built and linked against libc still.   This is problematic when using alpine based docker images.

This PR updates travis.yml to build and publish musl linked binaries using alpine docker image.