### PR TITLE
Add PDFWStreamForBuffer.

### DIFF
--- a/PDFWStreamForBuffer.js
+++ b/PDFWStreamForBuffer.js
@@ -1,0 +1,32 @@
+function PDFWStreamForBuffer()
+{
+    this.buffer = null;
+    this.position = 0;
+}
+
+PDFWStreamForBuffer.prototype.write = function(inBytesArray)
+{
+    if(inBytesArray.length > 0)
+    {
+        if(!this.buffer)
+        {
+            this.buffer = Buffer.from(inBytesArray);
+        }
+        else
+        {
+            this.buffer = Buffer.concat([this.buffer, Buffer.from(inBytesArray)]);
+        }
+
+        this.position += inBytesArray.length;
+        return inBytesArray.length;
+    }
+
+    return 0;
+};
+
+PDFWStreamForBuffer.prototype.getCurrentPosition = function()
+{
+    return this.position;
+};
+
+module.exports = PDFWStreamForBuffer;

--- a/hummus.js
+++ b/hummus.js
@@ -28,3 +28,4 @@ hummus.PDFStreamForResponse = require('./PDFStreamForResponse');
 hummus.PDFWStreamForFile = require('./PDFWStreamForFile');
 hummus.PDFRStreamForFile = require('./PDFRStreamForFile');
 hummus.PDFRStreamForBuffer = require('./PDFRStreamForBuffer');
+hummus.PDFWStreamForBuffer = require('./PDFWStreamForBuffer');


### PR DESCRIPTION
### Why ?

I felt it was missing in the base package as `PDFRStreamForBuffer` was available. It allows full PDF buffer management.

### Usage 

Pass it when creating writer, access the resulting `Buffer` with `PDFWStreamForBuffer.buffer` :

```js
let pdf = new PDFWStreamForBuffer();
let writer = createWriter(pdf);

writer.appendPDFPagesFromPDF(new PDFRStreamForBuffer(myPdfBuffer));
writer.end();

let resultingBuffer = pdf.buffer; // Here you get your PDF as a buffer
```