### PR TITLE
Fix segfault to allow tests running on Linux with electron 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,35 +14,9 @@ services:
   - docker
 env:
   matrix:
-    - NODE_NVM_VERSION="6.14.1"
-    - NODE_NVM_VERSION="7.10.1"
-    - NODE_NVM_VERSION="8.11.1"
-    - NODE_NVM_VERSION="9.11.1"
-    - NODE_NVM_VERSION="10.8.0"
-    - NODE_NVM_VERSION="11.2.0"
-    - NODE_NVM_VERSION="12.0.0"
-    - ELECTRON_VERSION="1.8.7" NODE_NVM_VERSION="8.11.1"
-    - ELECTRON_VERSION="2.0.7" NODE_NVM_VERSION="8.11.1"
-    - ELECTRON_VERSION="3.0.10" ELECTRON_MOCHA=true
-    - ELECTRON_VERSION="4.1.5" ELECTRON_MOCHA=true
     - ELECTRON_VERSION="5.0.0" ELECTRON_MOCHA=true    
-    - MUSL=true NODE_NVM_VERSION="9.11.1"
-    - MUSL=true NODE_NVM_VERSION="10.8.0"
-    - MUSL=true NODE_NVM_VERSION="11.2.0"    
+
 matrix:
-  exclude:
-    - os: osx
-      env: MUSL=true NODE_NVM_VERSION="9.11.1"
-    - os: osx
-      env: MUSL=true NODE_NVM_VERSION="10.8.0"
-    - os: osx
-      env: MUSL=true NODE_NVM_VERSION="11.2.0"
-    - os: linux
-      env: ELECTRON_VERSION="3.0.10" ELECTRON_MOCHA=true
-    - os: linux
-      env: ELECTRON_VERSION="4.1.5" ELECTRON_MOCHA=true
-    - os: linux
-      env: ELECTRON_VERSION="5.0.0" ELECTRON_MOCHA=true
   global:
     - secure: UwtG8rFAF8+tDmifVecoT9vm1ya/3iTK+pYSs0Qolo6Th6oMWv1pK/yE32iK4J0P4mRCE0OEV1FjhYpBp1zug6GaREV7cCaIexqY5m02AXsQ7jmNVRe4bQedaLYkJQP6xPCx26/Pu1ZHi+x6v8mDyqY9nSdlP7CL23iVobuw53Am/ZR5BK4bKB19HJiX2N1gqHHhzV1gFQxZBwxeLm55K7Fu+YbmUrPMMmR42alpiCSSyWJPhijDrVWdCA7ess73Hfu9vrrSEpRHgG+d2LXErTy1InRibmxwhEELgZMUmADMIyLk5YceoRNmESsWOfXUOrQGN5qjnomdd9+y7u2jXxaSnAPAlEcbZsMX7emVdsUlzacSEi/pMEVtSAgF6vCHFpkTMr+XtKUwJwu+c76kxAdfOSu1pY4Z6QsDvvfOF1OhBYiLM4ph7QfqEK0eS6lh6vJF6F1iwZ4BfEYcu7a8ANqv6d4odqLnGtMNJoJ7ijbDkxVoRP+pmh4tBNXMd23bpECR3U8iuWHPkWiMmXtIrgy7WzRqxomCrtuxO/ZetLm0ctsihsN7Z1Sgb3/hJiGO7oEZZBSzdF02/Q1umPz6xvqbvQJp+VA/CqSq0+fx+DGacxOOQar87N268d0Y62q1i02eyvzBgY8X9awN4EvIp16yRCJCNart7T4dIkurSwE=
     - secure: OFo+Aqvq/FJLey1wXN8IrRw42aoccTIX90d9DFrpIieJ436WDpBdl3QgzPuCrJiBW9VxCdgzF1xvkFm1+VwzqvqXgAZfTJeJ2AhDjltzHtN+QzJx7SwQcsMAEbSgdLbboGJuyf1yeCs5x95792U+CXm3xy+zLkKw9XO9682WaO6uAp6mVX0wD7Z6u8qLbwMI6YXcY99rptiEtQ4TzKWHQI4m5dSHkCISmNGtBOuOZEF8v3FJ8TzEmjEJ1FNRrjAcwFcTgIwoHudmrs/GGaWBpwyq24XmBG8cavDeKaezmL80vBbGJaOR9IdVwYKNaeslNZBCxGoq3Cy1ReB2cECPw2yhFUktlHqr4SzzCt8JgMgtH8dLajQTdpznJssJesGfz4kwBu+IKGxrIqkh6/YEtYJFEUaaVBjyt7uyuXefZpoz19E63ZzqtrtHRFhdru4aEaUk6CibfljMMaLnxnvdkhQljz5SAhgh55aAUCejh1mgFIR5O3W4AD/3zrIL6HDOLEbYmFbDAsYIoPqp5g+9oiJ6sPyO75wtlFo4ciaw5K7o1y4NTh9BCB7j0P3FYAMqf2Z/wT2kU6W0MKFyo6AmOL4w7uwT/OAgYbWn1hgG2toAtatFrXnUu5CQTBwxel4uTiLkJIa1Zoy53BJxzDUVGgDvs/+sjV3lIr5J09B2kmA=
@@ -77,6 +51,7 @@ install:
     npm install --build-from-source;
     fi
 script:
+  - if [[ $ELECTRON_MOCHA ]]; then export DISPLAY=:99.0; sh -e /etc/init.d/xvfb start; fi
   - if [[ $MUSL ]]; then
     scripts/alpine-test.sh ./node_modules/.bin/node-pre-gyp package testpackage $EXTRA_NODE_PRE_GYP_FLAGS;
     elif [[ $ELECTRON_MOCHA ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ matrix:
     - secure: UwtG8rFAF8+tDmifVecoT9vm1ya/3iTK+pYSs0Qolo6Th6oMWv1pK/yE32iK4J0P4mRCE0OEV1FjhYpBp1zug6GaREV7cCaIexqY5m02AXsQ7jmNVRe4bQedaLYkJQP6xPCx26/Pu1ZHi+x6v8mDyqY9nSdlP7CL23iVobuw53Am/ZR5BK4bKB19HJiX2N1gqHHhzV1gFQxZBwxeLm55K7Fu+YbmUrPMMmR42alpiCSSyWJPhijDrVWdCA7ess73Hfu9vrrSEpRHgG+d2LXErTy1InRibmxwhEELgZMUmADMIyLk5YceoRNmESsWOfXUOrQGN5qjnomdd9+y7u2jXxaSnAPAlEcbZsMX7emVdsUlzacSEi/pMEVtSAgF6vCHFpkTMr+XtKUwJwu+c76kxAdfOSu1pY4Z6QsDvvfOF1OhBYiLM4ph7QfqEK0eS6lh6vJF6F1iwZ4BfEYcu7a8ANqv6d4odqLnGtMNJoJ7ijbDkxVoRP+pmh4tBNXMd23bpECR3U8iuWHPkWiMmXtIrgy7WzRqxomCrtuxO/ZetLm0ctsihsN7Z1Sgb3/hJiGO7oEZZBSzdF02/Q1umPz6xvqbvQJp+VA/CqSq0+fx+DGacxOOQar87N268d0Y62q1i02eyvzBgY8X9awN4EvIp16yRCJCNart7T4dIkurSwE=
     - secure: OFo+Aqvq/FJLey1wXN8IrRw42aoccTIX90d9DFrpIieJ436WDpBdl3QgzPuCrJiBW9VxCdgzF1xvkFm1+VwzqvqXgAZfTJeJ2AhDjltzHtN+QzJx7SwQcsMAEbSgdLbboGJuyf1yeCs5x95792U+CXm3xy+zLkKw9XO9682WaO6uAp6mVX0wD7Z6u8qLbwMI6YXcY99rptiEtQ4TzKWHQI4m5dSHkCISmNGtBOuOZEF8v3FJ8TzEmjEJ1FNRrjAcwFcTgIwoHudmrs/GGaWBpwyq24XmBG8cavDeKaezmL80vBbGJaOR9IdVwYKNaeslNZBCxGoq3Cy1ReB2cECPw2yhFUktlHqr4SzzCt8JgMgtH8dLajQTdpznJssJesGfz4kwBu+IKGxrIqkh6/YEtYJFEUaaVBjyt7uyuXefZpoz19E63ZzqtrtHRFhdru4aEaUk6CibfljMMaLnxnvdkhQljz5SAhgh55aAUCejh1mgFIR5O3W4AD/3zrIL6HDOLEbYmFbDAsYIoPqp5g+9oiJ6sPyO75wtlFo4ciaw5K7o1y4NTh9BCB7j0P3FYAMqf2Z/wT2kU6W0MKFyo6AmOL4w7uwT/OAgYbWn1hgG2toAtatFrXnUu5CQTBwxel4uTiLkJIa1Zoy53BJxzDUVGgDvs/+sjV3lIr5J09B2kmA=
 before_install:
+  - if [[ $TRAVIS_OS_NAME == "linux" ]]; then export DISPLAY=:99.0; sh -e /etc/init.d/xvfb start; fi
   - if [[ $TRAVIS_OS_NAME == "linux" ]]; then export CXX=g++-4.8; fi
   - if [[ $ELECTRON_VERSION ]]; then
     export npm_config_target=$ELECTRON_VERSION;
@@ -51,7 +52,6 @@ install:
     npm install --build-from-source;
     fi
 script:
-  - if [[ $ELECTRON_MOCHA ]]; then export DISPLAY=:99.0; sh -e /etc/init.d/xvfb start; fi
   - if [[ $MUSL ]]; then
     scripts/alpine-test.sh ./node_modules/.bin/node-pre-gyp package testpackage $EXTRA_NODE_PRE_GYP_FLAGS;
     elif [[ $ELECTRON_MOCHA ]]; then

--- a/src/deps/PDFWriter/PNGImageHandler.cpp
+++ b/src/deps/PDFWriter/PNGImageHandler.cpp
@@ -275,7 +275,7 @@ void HandlePngError(png_structp png_ptr, png_const_charp error_message) {
 		if (error_message)
 			TRACE_LOG1("LibPNG Error: %s", error_message);
 	}
-	png_longjmp(png_ptr, 1);
+	// png_longjmp(png_ptr, 1);
 }
 
 void HandlePngWarning(png_structp png_ptr, png_const_charp warning_message) {


### PR DESCRIPTION
This is only a draft PR showing the cause of the segmentation fault.
There are several things which are beyond me and i try to document how i achieved testing / seeing the issue.

First of all i created a vagarnt image based on trusty64 and tried to compile which always lead to an error compiling that the `libdbus-1.so.3` has ne version information.
So i upgraded to xenial which gave me a good compiled bin.

Now i tried to dig down the `electron-mocha` path and tried to use strace and gdb.
First of all i needed to find out which tests are failing and its:

```BasicPNGImagesTest.js``` fails with a segfault and reducing it to the following:

```
var pdfWriter = require('../hummus').createWriter(__dirname + '/output/BasicPNGImagesTest.pdf',{log:__dirname + '/output/BasicPNGImagesTest.log'});

        var imageOptions = {transformation:[0.5,0,0,0.5,0,0]}

        var page = pdfWriter.createPage(0,0,595,842);
        pdfWriter.startPageContentContext(page)
            .drawImage(10,200,__dirname+'/TestMaterials/images/png/original.png',imageOptions);
        pdfWriter.writePage(page);
        pdfWriter.end()
```

But its not only the `drawImage` function, when digging deeper its root cause is from :
`createFormXObjectFromPNG` which also fails.

Side note: 
PNG and JPEG tests do the tests differently, JPEG uses the more sophisticated drawing API and PNG the higher level convinience functions.

I installed `gdb` and printed the command line args:

```gdb --args /home/ubuntu/.nvm/versions/node/v11.2.0/lib/node_modules/electron/dist/electron /home/ubuntu/.nvm/versions/node/v11.2.0/lib/node_modules/electron-mocha/lib/main.js ./tests/BasicPNGImagesTest.js```

When running the debugger the segfault is in vsprintf.c which confused me that the error message should not be defined.

But in the end when removing the `png_longjmp` function in `deps/PDFWriter/PNGImageHandler.cpp`
the code is running without a segfault.
I did not manage to look into the struct ptr what is happening inside there,
but its not a NULL pointer.

Why this is working with an electron 1.8.7 i've no idea.

Anyway the test can not succeed as electron (since ever?) is compiled against a LibPNG 1.2. 
and the deps have added LibPNG 1.6.x.

This is the output from the test log:
```
[ 27/06/2019 07:17:35 ] LibPNG Warning: Application was compiled with png.h from libpng-1.6.32
[ 27/06/2019 07:17:35 ] LibPNG Warning: Application  is  running with png.c from libpng-1.2.54
[ 27/06/2019 07:18:17 ] LibPNG Error: Incompatible libpng version in application and library
/home/ubuntu/module/tests/output/BasicPNGImagesTest.log
```

I tried to downgrade LibPNG, but the API changed so that i've got a bunch of compile errors when exchanging sources.

Edit:

The backtrace from gdb:
```
#0  0x00007ffff1402cc0 in _IO_vfprintf_internal (s=s@entry=0x7fffffffc410, format=<optimized out>,
    format@entry=0x7fffdd6cc5b1 "LibPNG Error: %s", ap=ap@entry=0x7fffffffc548) at vfprintf.c:1632
#1  0x00007ffff14ca754 in ___vsprintf_chk (
    s=0x7fffdd973e00 <Trace::DefaultTrace()::default_trace> "LibPNG Error: Incompatible libpng version in application and library", flags=1, slen=50001, format=0x7fffdd6cc5b1 "LibPNG Error: %s",
    args=0x7fffffffc548) at vsprintf_chk.c:82
#2  0x00007fffdd56d870 in Trace::TraceToLog(char const*, ...) ()
   from /home/ubuntu/module/binding/hummus.node
#3  0x00007fffdd55caab in HandlePngError(png_struct_def*, char const*) ()
   from /home/ubuntu/module/binding/hummus.node
#4  0x00007fffdd695a63 in png_longjmp () from /home/ubuntu/module/binding/hummus.node
#5  0x00007fffdd55cac2 in HandlePngError(png_struct_def*, char const*) ()
   from /home/ubuntu/module/binding/hummus.node
#6  0x00007fffee319647 in png_error () from /lib/x86_64-linux-gnu/libpng12.so.0
#7  0x00007fffee30e892 in png_create_read_struct_2 () from /lib/x86_64-linux-gnu/libpng12.so.0
#8  0x00007fffee30ea61 in png_create_read_struct () from /lib/x86_64-linux-gnu/libpng12.so.0
#9  0x00007fffdd55d7c8 in CreateFormXObjectForPNGStream(IByteReaderWithPosition*, PDFHummus::DocumentContext*, ObjectsContext*, unsigned long) () from /home/ubuntu/module/binding/hummus.node
#10 0x00007fffdd51dd39 in PDFHummus::DocumentContext::WriteFormForImage(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, unsigned long, unsigned long, PDFParsingOptions const&) () from /home/ubuntu/module/binding/hummus.node
#11 0x00007fffdd51c9dc in PDFHummus::DocumentContext::WritePage(PDFPage*) ()
   from /home/ubuntu/module/binding/hummus.node
#12 0x00007fffdd55a09d in PDFWriter::WritePageAndReturnPageID(PDFPage*) ()
   from /home/ubuntu/module/binding/hummus.node
#13 0x00007fffdd4eaccc in PDFWriterDriver::WritePageAndReturnID(v8::FunctionCallbackInfo<v8::Value> const&) () from /home/ubuntu/module/binding/hummus.node
#14 0x00007fffdd4eae79 in PDFWriterDriver::WritePage(v8::FunctionCallbackInfo<v8::Value> const&) ()
```
