### PR TITLE
Add missing electron 4.2 windows prebuilt

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,12 +25,17 @@ environment:
     - nodejs_version: 10
       platform: x64
       NODE_RUNTIME: electron
+      NODE_RUNTIME_VERSION: 4.2.8
+      TOOLSET_ARGS: --dist-url=https://atom.io/download/electron        
+    - nodejs_version: 10
+      platform: x64
+      NODE_RUNTIME: electron
       NODE_RUNTIME_VERSION: 4.1.5
       TOOLSET_ARGS: --dist-url=https://atom.io/download/electron
     - nodejs_version: 10
       platform: x64
       NODE_RUNTIME: electron
-      NODE_RUNTIME_VERSION: 4.2.8
+      NODE_RUNTIME_VERSION: 4.0.8
       TOOLSET_ARGS: --dist-url=https://atom.io/download/electron      
     - nodejs_version: 10
       platform: x64

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,6 +30,11 @@ environment:
     - nodejs_version: 10
       platform: x64
       NODE_RUNTIME: electron
+      NODE_RUNTIME_VERSION: 4.2.8
+      TOOLSET_ARGS: --dist-url=https://atom.io/download/electron      
+    - nodejs_version: 10
+      platform: x64
+      NODE_RUNTIME: electron
       NODE_RUNTIME_VERSION: 3.0.9
       TOOLSET_ARGS: --dist-url=https://atom.io/download/electron
     - nodejs_version: 8


### PR DESCRIPTION
This is really a pain, but for electron you need for each minor version a new prebuilt and for electron 4.2 one is missing on windows.

Could you please publish new binaries with this @galkahana . Thanks.