### PR TITLE
Added support for image stream on PDFWriter::getImageDimensions

### DIFF
--- a/hummus.d.ts
+++ b/hummus.d.ts
@@ -668,7 +668,7 @@ SET_PROTOTYPE_METHOD(t, "allocateNewObjectID", AllocateNewObjectID);
     createPDFTextString();
     createPDFDate();
     */
-    getImageDimensions(inFontFilePath: FilePath): RectangleDimension;
+    getImageDimensions(inFontFilePath: FilePath | ReadStream): RectangleDimension;
     /*
     getImagePagesCount();
     getImageType();

--- a/src/PDFWriterDriver.cpp
+++ b/src/PDFWriterDriver.cpp
@@ -1,21 +1,21 @@
 /*
  Source File : PDFWriterDriver.cpp
- 
- 
+
+
  Copyright 2013 Gal Kahana HummusJS
- 
+
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
- 
+
  http://www.apache.org/licenses/LICENSE-2.0
- 
+
  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  See the License for the specific language governing permissions and
  limitations under the License.
- 
+
  */
 #include "PDFWriterDriver.h"
 #include "PDFPageDriver.h"
@@ -66,7 +66,7 @@ PDFWriterDriver::~PDFWriterDriver()
 DEF_SUBORDINATE_INIT(PDFWriterDriver::Init)
 {
 	CREATE_ISOLATE_CONTEXT;
-    
+
 	Local<FunctionTemplate> t = NEW_FUNCTION_TEMPLATE_EXTERNAL(New);
 
 	t->SetClassName(NEW_STRING("PDFWriter"));
@@ -104,12 +104,12 @@ DEF_SUBORDINATE_INIT(PDFWriterDriver::Init)
 	SET_PROTOTYPE_METHOD(t, "getModifiedInputFile", GetModifiedInputFile);
 	SET_PROTOTYPE_METHOD(t, "getOutputFile", GetOutputFile);
 	SET_PROTOTYPE_METHOD(t, "registerAnnotationReferenceForNextPageWrite", RegisterAnnotationReferenceForNextPageWrite);
-    SET_PROTOTYPE_METHOD(t, "requireCatalogUpdate", RequireCatalogUpdate);    
+    SET_PROTOTYPE_METHOD(t, "requireCatalogUpdate", RequireCatalogUpdate);
     SET_CONSTRUCTOR_EXPORT("PDFWriter", t);
 
     // save in factory
 	EXPOSE_EXTERNAL_FOR_INIT(ConstructorsHolder, holder)
-    SET_CONSTRUCTOR(holder->PDFWriter_constructor, t);    
+    SET_CONSTRUCTOR(holder->PDFWriter_constructor, t);
 }
 
 METHOD_RETURN_TYPE PDFWriterDriver::New(const ARGS_TYPE& args)
@@ -117,12 +117,12 @@ METHOD_RETURN_TYPE PDFWriterDriver::New(const ARGS_TYPE& args)
     CREATE_ISOLATE_CONTEXT;
 	CREATE_ESCAPABLE_SCOPE;
     EXPOSE_EXTERNAL_ARGS(ConstructorsHolder, externalHolder)
-    
+
     PDFWriterDriver* pdfWriter = new PDFWriterDriver();
-        
-    pdfWriter->holder = externalHolder;    
+
+    pdfWriter->holder = externalHolder;
     pdfWriter->Wrap(args.This());
-    
+
 	SET_FUNCTION_RETURN_VALUE(args.This())
 }
 
@@ -130,38 +130,38 @@ METHOD_RETURN_TYPE PDFWriterDriver::End(const ARGS_TYPE& args)
 {
     CREATE_ISOLATE_CONTEXT;
 	CREATE_ESCAPABLE_SCOPE;
-   
+
     PDFWriterDriver* pdfWriter = ObjectWrap::Unwrap<PDFWriterDriver>(args.This());
-    
+
     EStatusCode status;
-    
+
     if(pdfWriter->mStartedWithStream)
         status = pdfWriter->mPDFWriter.EndPDFForStream();
     else
         status = pdfWriter->mPDFWriter.EndPDF();
-    
+
     // now remove event listener
     pdfWriter->mPDFWriter.GetDocumentContext().AddDocumentContextExtender(pdfWriter);
 
-    
+
     if(status != PDFHummus::eSuccess)
     {
 		THROW_EXCEPTION("Unable to end PDF");
 		SET_FUNCTION_RETURN_VALUE(UNDEFINED)
     }
-    
+
     if(pdfWriter->mWriteStreamProxy)
     {
         delete pdfWriter->mWriteStreamProxy;
         pdfWriter->mWriteStreamProxy = NULL;
     }
-    
+
     if(pdfWriter->mReadStreamProxy)
     {
         delete pdfWriter->mReadStreamProxy;
         pdfWriter->mReadStreamProxy = NULL;
     }
-    
+
     SET_FUNCTION_RETURN_VALUE(args.This())
 }
 
@@ -170,41 +170,41 @@ METHOD_RETURN_TYPE PDFWriterDriver::CreatePage(const ARGS_TYPE& args)
     CREATE_ISOLATE_CONTEXT;
 	CREATE_ESCAPABLE_SCOPE;
     PDFWriterDriver* pdfWriter = ObjectWrap::Unwrap<PDFWriterDriver>(args.This());
-    
+
     SET_FUNCTION_RETURN_VALUE(pdfWriter->holder->GetNewPDFPage(args))
-    
+
 }
 
 METHOD_RETURN_TYPE PDFWriterDriver::WritePage(const ARGS_TYPE& args)
 {
     CREATE_ISOLATE_CONTEXT;
 	CREATE_ESCAPABLE_SCOPE;
-    
+
     WritePageAndReturnID(args);
-    
+
     SET_FUNCTION_RETURN_VALUE(args.This())
-    
+
 }
 
 METHOD_RETURN_TYPE PDFWriterDriver::WritePageAndReturnID(const ARGS_TYPE& args)
 {
     CREATE_ISOLATE_CONTEXT;
 	CREATE_ESCAPABLE_SCOPE;
-    
+
     PDFWriterDriver* pdfWriter = ObjectWrap::Unwrap<PDFWriterDriver>(args.This());
-    
+
 	if (args.Length() != 1 || !pdfWriter->holder->IsPDFPageInstance(args[0])) {
 		THROW_EXCEPTION("Wrong arguments, provide a page as the single parameter");
 		SET_FUNCTION_RETURN_VALUE(UNDEFINED)
 	}
-    
+
     PDFPageDriver* pageDriver = ObjectWrap::Unwrap<PDFPageDriver>(args[0]->TO_OBJECT());
     if(!pageDriver)
     {
 		THROW_EXCEPTION("Wrong arguments, provide a page as the single parameter");
 		SET_FUNCTION_RETURN_VALUE(UNDEFINED)
     }
-    
+
     if(pageDriver->ContentContext &&
        (pdfWriter->mPDFWriter.EndPageContentContext(pageDriver->ContentContext) != PDFHummus::eSuccess))
     {
@@ -212,47 +212,47 @@ METHOD_RETURN_TYPE PDFWriterDriver::WritePageAndReturnID(const ARGS_TYPE& args)
 		SET_FUNCTION_RETURN_VALUE(UNDEFINED)
     }
     pageDriver->ContentContext = NULL;
-    
+
     EStatusCodeAndObjectIDType result = pdfWriter->mPDFWriter.WritePageAndReturnPageID(pageDriver->GetPage());
-    
+
     if(result.first != PDFHummus::eSuccess)
     {
 		THROW_EXCEPTION("Unable to write page");
 		SET_FUNCTION_RETURN_VALUE(UNDEFINED)
     }
-    
+
     SET_FUNCTION_RETURN_VALUE(NEW_NUMBER(result.second))
-    
+
 }
 
 METHOD_RETURN_TYPE PDFWriterDriver::StartPageContentContext(const ARGS_TYPE& args)
 {
     CREATE_ISOLATE_CONTEXT;
 	CREATE_ESCAPABLE_SCOPE;
-    
+
     PDFWriterDriver* pdfWriter = ObjectWrap::Unwrap<PDFWriterDriver>(args.This());
-    
+
 	if (args.Length() != 1 || !pdfWriter->holder->IsPDFPageInstance(args[0])) {
 		THROW_EXCEPTION("Wrong arguments, provide a page as the single parameter");
 		SET_FUNCTION_RETURN_VALUE(UNDEFINED)
 	}
-    
+
     PDFPageDriver* pageDriver = ObjectWrap::Unwrap<PDFPageDriver>(args[0]->TO_OBJECT());
     if(!pageDriver)
     {
 		THROW_EXCEPTION("Wrong arguments, provide a page as the single parameter");
 		SET_FUNCTION_RETURN_VALUE(UNDEFINED)
     }
-    
-    
+
+
     Local<Value> newInstance = pdfWriter->holder->GetNewPageContentContext(args);
     PageContentContextDriver* contentContextDriver = ObjectWrap::Unwrap<PageContentContextDriver>(newInstance->TO_OBJECT());
     contentContextDriver->ContentContext = pdfWriter->mPDFWriter.StartPageContentContext(pageDriver->GetPage());
     contentContextDriver->SetResourcesDictionary(&(pageDriver->GetPage()->GetResourcesDictionary()));
-    
+
     // save it also at page driver, so we can end the context when the page is written
     pageDriver->ContentContext = contentContextDriver->ContentContext;
-    
+
     SET_FUNCTION_RETURN_VALUE(newInstance)
 }
 
@@ -260,29 +260,29 @@ METHOD_RETURN_TYPE PDFWriterDriver::PausePageContentContext(const ARGS_TYPE& arg
 {
     CREATE_ISOLATE_CONTEXT;
 	CREATE_ESCAPABLE_SCOPE;
-    
+
     PDFWriterDriver* pdfWriter = ObjectWrap::Unwrap<PDFWriterDriver>(args.This());
-    
+
 	if (args.Length() != 1 || !pdfWriter->holder->IsPageContentContextInstance(args[0])) {
 		THROW_EXCEPTION("Wrong arguments, provide a page context as the single parameter");
 		SET_FUNCTION_RETURN_VALUE(UNDEFINED)
 	}
-    
+
     PageContentContextDriver* pageContextDriver = ObjectWrap::Unwrap<PageContentContextDriver>(args[0]->TO_OBJECT());
     if(!pageContextDriver)
     {
 		THROW_EXCEPTION("Wrong arguments, provide a page context as the single parameter");
 		SET_FUNCTION_RETURN_VALUE(UNDEFINED)
     }
-    
+
     if(!pageContextDriver->ContentContext)
     {
 		THROW_EXCEPTION("paused context not initialized, please create one using pdfWriter.startPageContentContext");
 		SET_FUNCTION_RETURN_VALUE(UNDEFINED)
     }
-    
+
     pdfWriter->mPDFWriter.PausePageContentContext(pageContextDriver->ContentContext);
-    
+
     SET_FUNCTION_RETURN_VALUE(args.This())
 }
 
@@ -290,14 +290,14 @@ METHOD_RETURN_TYPE PDFWriterDriver::CreateFormXObject(const ARGS_TYPE& args)
 {
     CREATE_ISOLATE_CONTEXT;
 	CREATE_ESCAPABLE_SCOPE;
-    
+
     if((args.Length() != 4  && args.Length() != 5) || !args[0]->IsNumber() || !args[1]->IsNumber() || !args[2]->IsNumber() || !args[3]->IsNumber()
         || (args.Length() == 5 && !args[4]->IsNumber()))
     {
 		THROW_EXCEPTION("wrong arguments, pass 4 coordinates of the form rectangle and an optional 5th agument which is the forward reference ID");
 		SET_FUNCTION_RETURN_VALUE(UNDEFINED)
     }
-     
+
     PDFWriterDriver* pdfWriter = ObjectWrap::Unwrap<PDFWriterDriver>(args.This());
     Local<Value> newInstance = pdfWriter->holder->GetNewFormXObject(args);
     FormXObjectDriver* formXObjectDriver = ObjectWrap::Unwrap<FormXObjectDriver>(newInstance->TO_OBJECT());
@@ -321,25 +321,25 @@ METHOD_RETURN_TYPE PDFWriterDriver::EndFormXObject(const ARGS_TYPE& args)
 {
     CREATE_ISOLATE_CONTEXT;
 	CREATE_ESCAPABLE_SCOPE;
-    
+
     PDFWriterDriver* pdfWriter = ObjectWrap::Unwrap<PDFWriterDriver>(args.This());
-    
+
 	if (args.Length() != 1 || !pdfWriter->holder->IsFormXObjectInstance(args[0])) {
 		THROW_EXCEPTION("Wrong arguments, provide a form as the single parameter");
 		SET_FUNCTION_RETURN_VALUE(UNDEFINED)
 	}
-    
+
     FormXObjectDriver* formContextDriver = ObjectWrap::Unwrap<FormXObjectDriver>(args[0]->TO_OBJECT());
     if(!formContextDriver)
     {
 		THROW_EXCEPTION("Wrong arguments, provide a form as the single parameter");
 		SET_FUNCTION_RETURN_VALUE(UNDEFINED)
     }
-        
+
     pdfWriter->mPDFWriter.EndFormXObject(formContextDriver->FormXObject);
-    
+
     SET_FUNCTION_RETURN_VALUE(args.This())
-    
+
 }
 
 
@@ -348,26 +348,26 @@ METHOD_RETURN_TYPE PDFWriterDriver::CreateformXObjectFromJPG(const ARGS_TYPE& ar
 {
     CREATE_ISOLATE_CONTEXT;
 	CREATE_ESCAPABLE_SCOPE;
-    
+
     if((args.Length() != 1  && args.Length() != 2 ) || (!args[0]->IsString() && !args[0]->IsObject()) || (args.Length() == 2 && !args[1]->IsNumber()))
     {
 		THROW_EXCEPTION("wrong arguments, pass 1 argument that is the path to the image or an image stream. Optionally pass an object ID for a forward reference image");
 		SET_FUNCTION_RETURN_VALUE(UNDEFINED)
     }
-    
+
     PDFWriterDriver* pdfWriter = ObjectWrap::Unwrap<PDFWriterDriver>(args.This());
-    
+
     PDFFormXObject* formXObject;
-    
+
     if(args[0]->IsObject())
     {
         ObjectByteReaderWithPosition proxy(args[0]->TO_OBJECT());
-        
+
         formXObject =
         args.Length() == 2 ?
         pdfWriter->mPDFWriter.CreateFormXObjectFromJPGStream(&proxy,(ObjectIDType)TO_INT32(args[1])->Value()):
         pdfWriter->mPDFWriter.CreateFormXObjectFromJPGStream(&proxy);
-        
+
     }
     else
     {
@@ -381,7 +381,7 @@ METHOD_RETURN_TYPE PDFWriterDriver::CreateformXObjectFromJPG(const ARGS_TYPE& ar
 		THROW_EXCEPTION("unable to create form xobject. verify that the target is an existing jpg file/stream");
 		SET_FUNCTION_RETURN_VALUE(UNDEFINED)
     }
-    
+
     Local<Value> newInstance = pdfWriter->holder->GetNewFormXObject(args);
     ObjectWrap::Unwrap<FormXObjectDriver>(newInstance->TO_OBJECT())->FormXObject = formXObject;
     SET_FUNCTION_RETURN_VALUE(newInstance)
@@ -391,25 +391,25 @@ METHOD_RETURN_TYPE PDFWriterDriver::RetrieveJPGImageInformation(const ARGS_TYPE&
 {
     CREATE_ISOLATE_CONTEXT;
 	CREATE_ESCAPABLE_SCOPE;
-    
+
     if(args.Length() != 1  ||
        !args[0]->IsString())
     {
 		THROW_EXCEPTION("wrong arguments, pass 1 argument that is the path to the image");
 		SET_FUNCTION_RETURN_VALUE(UNDEFINED)
     }
-    
+
     PDFWriterDriver* pdfWriter = ObjectWrap::Unwrap<PDFWriterDriver>(args.This());
     BoolAndJPEGImageInformation info = pdfWriter->mPDFWriter.GetDocumentContext().GetJPEGImageHandler().RetrieveImageInformation(*UTF_8_VALUE(args[0]->TO_STRING()));
-    
+
     if(!info.first)
     {
 		THROW_EXCEPTION("unable to retrieve image information");
 		SET_FUNCTION_RETURN_VALUE(UNDEFINED)
     }
-    
+
     Local<Object> result = NEW_OBJECT;
-    
+
 	result->Set(GET_CURRENT_CONTEXT, NEW_SYMBOL("samplesWidth"), NEW_INTEGER((int)info.second.SamplesWidth));
 	result->Set(GET_CURRENT_CONTEXT, NEW_SYMBOL("samplesHeight"), NEW_INTEGER((int)info.second.SamplesHeight));
 	result->Set(GET_CURRENT_CONTEXT, NEW_SYMBOL("colorComponentsCount"), NEW_INTEGER(info.second.ColorComponentsCount));
@@ -441,26 +441,26 @@ METHOD_RETURN_TYPE PDFWriterDriver::CreateFormXObjectFromPNG(const ARGS_TYPE& ar
 {
     CREATE_ISOLATE_CONTEXT;
 	CREATE_ESCAPABLE_SCOPE;
-    
+
     if((args.Length() != 1  && args.Length() != 2 ) || (!args[0]->IsString() && !args[0]->IsObject()) || (args.Length() == 2 && !args[1]->IsNumber()))
     {
 		THROW_EXCEPTION("wrong arguments, pass 1 argument that is the path to the image or an image stream. Optionally pass an object ID for a forward reference image");
 		SET_FUNCTION_RETURN_VALUE(UNDEFINED)
     }
-    
+
     PDFWriterDriver* pdfWriter = ObjectWrap::Unwrap<PDFWriterDriver>(args.This());
-    
+
     PDFFormXObject* formXObject;
-    
+
     if(args[0]->IsObject())
     {
         ObjectByteReaderWithPosition proxy(args[0]->TO_OBJECT());
-        
+
         formXObject =
         args.Length() == 2 ?
         pdfWriter->mPDFWriter.CreateFormXObjectFromPNGStream(&proxy,(ObjectIDType)TO_INT32(args[1])->Value()):
         pdfWriter->mPDFWriter.CreateFormXObjectFromPNGStream(&proxy);
-        
+
     }
     else
     {
@@ -474,7 +474,7 @@ METHOD_RETURN_TYPE PDFWriterDriver::CreateFormXObjectFromPNG(const ARGS_TYPE& ar
 		THROW_EXCEPTION("unable to create form xobject. verify that the target is an existing png file/stream");
 		SET_FUNCTION_RETURN_VALUE(UNDEFINED)
     }
-    
+
     Local<Value> newInstance = pdfWriter->holder->GetNewFormXObject(args);
     ObjectWrap::Unwrap<FormXObjectDriver>(newInstance->TO_OBJECT())->FormXObject = formXObject;
     SET_FUNCTION_RETURN_VALUE(newInstance)
@@ -484,7 +484,7 @@ METHOD_RETURN_TYPE PDFWriterDriver::GetFontForFile(const ARGS_TYPE& args)
 {
     CREATE_ISOLATE_CONTEXT;
 	CREATE_ESCAPABLE_SCOPE;
-    
+
     if(args.Length() < 1 ||
         !args[0]->IsString() ||
                 (args.Length() == 2 && !args[1]->IsString() && !args[1]->IsNumber()) ||
@@ -493,11 +493,11 @@ METHOD_RETURN_TYPE PDFWriterDriver::GetFontForFile(const ARGS_TYPE& args)
 		THROW_EXCEPTION("wrong arguments, pass 1 argument that is the path to the font file, with option to a 2nd parameter for another path in case of type 1 font. another optional argument may follow with font index in case of font packages (TTC, DFont)");
 		SET_FUNCTION_RETURN_VALUE(UNDEFINED)
     }
-    
+
     PDFWriterDriver* pdfWriter = ObjectWrap::Unwrap<PDFWriterDriver>(args.This());
-    
+
     PDFUsedFont* usedFont;
-    
+
     if(args.Length() == 3)
     {
         usedFont = pdfWriter->mPDFWriter.GetFontForFile(*UTF_8_VALUE(args[0]->TO_STRING()),
@@ -517,13 +517,13 @@ METHOD_RETURN_TYPE PDFWriterDriver::GetFontForFile(const ARGS_TYPE& args)
     {
         usedFont = pdfWriter->mPDFWriter.GetFontForFile(*UTF_8_VALUE(args[0]->TO_STRING()));
     }
-    
+
     if(!usedFont)
     {
 		THROW_EXCEPTION("unable to create font object. verify that the target is an existing and supported font type (ttf,otf,type1,dfont,ttc)");
 		SET_FUNCTION_RETURN_VALUE(UNDEFINED)
     }
-    
+
     Local<Value> newInstance = pdfWriter->holder->GetNewUsedFont(args);
     ObjectWrap::Unwrap<UsedFontDriver>(newInstance->TO_OBJECT())->UsedFont = usedFont;
     SET_FUNCTION_RETURN_VALUE(newInstance)
@@ -533,7 +533,7 @@ METHOD_RETURN_TYPE PDFWriterDriver::AttachURLLinktoCurrentPage(const ARGS_TYPE& 
 {
     CREATE_ISOLATE_CONTEXT;
 	CREATE_ESCAPABLE_SCOPE;
-    
+
     if(args.Length() != 5 ||
         !args[0]->IsString() ||
         !args[1]->IsNumber() ||
@@ -544,9 +544,9 @@ METHOD_RETURN_TYPE PDFWriterDriver::AttachURLLinktoCurrentPage(const ARGS_TYPE& 
 		THROW_EXCEPTION("wrong arguments, pass a url, and 4 numbers (left,bottom,right,top) for the rectangle valid for clicking");
 		SET_FUNCTION_RETURN_VALUE(UNDEFINED)
     }
-    
+
     PDFWriterDriver* pdfWriter = ObjectWrap::Unwrap<PDFWriterDriver>(args.This());
-    
+
     EStatusCode status = pdfWriter->mPDFWriter.AttachURLLinktoCurrentPage(*UTF_8_VALUE(args[0]->TO_STRING()),
                                                                              PDFRectangle(TO_NUMBER(args[1])->Value(),
                                                                              TO_NUMBER(args[2])->Value(),
@@ -557,7 +557,7 @@ METHOD_RETURN_TYPE PDFWriterDriver::AttachURLLinktoCurrentPage(const ARGS_TYPE& 
 		THROW_EXCEPTION("unable to attach link to current page. will happen if the input URL may not be encoded to ascii7");
 		SET_FUNCTION_RETURN_VALUE(UNDEFINED)
     }
-    
+
     SET_FUNCTION_RETURN_VALUE(args.This())
 }
 
@@ -566,23 +566,23 @@ METHOD_RETURN_TYPE PDFWriterDriver::Shutdown(const ARGS_TYPE& args)
 {
     CREATE_ISOLATE_CONTEXT;
 	CREATE_ESCAPABLE_SCOPE;
-    
+
     if(args.Length() != 1 ||
        !args[0]->IsString())
     {
 		THROW_EXCEPTION("wrong arguments, pass a path to save the state file to");
 		SET_FUNCTION_RETURN_VALUE(UNDEFINED)
     }
-    
+
     PDFWriterDriver* pdfWriter = ObjectWrap::Unwrap<PDFWriterDriver>(args.This());
-    
+
     EStatusCode status = pdfWriter->mPDFWriter.Shutdown(*UTF_8_VALUE(args[0]->TO_STRING()));
     if(status != eSuccess)
     {
 		THROW_EXCEPTION("unable to save state file. verify that path is not occupied");
 		SET_FUNCTION_RETURN_VALUE(UNDEFINED)
     }
-    
+
     SET_FUNCTION_RETURN_VALUE(args.This())
 }
 
@@ -592,7 +592,7 @@ PDFHummus::EStatusCode PDFWriterDriver::StartPDF(const std::string& inOutputFile
                                                  const PDFCreationSettings& inCreationSettings)
 {
     mStartedWithStream = false;
-    
+
     return setupListenerIfOK(mPDFWriter.StartPDF(inOutputFilePath,inPDFVersion,inLogConfiguration,inCreationSettings));
 }
 
@@ -627,8 +627,8 @@ PDFHummus::EStatusCode PDFWriterDriver::ContinuePDF(Local<Object> inOutputStream
    mWriteStreamProxy = new ObjectByteWriterWithPosition(inOutputStream);
     if(!inModifiedSourceStream.IsEmpty())
         mReadStreamProxy = new ObjectByteReaderWithPosition(inModifiedSourceStream);
-    
-    
+
+
     return setupListenerIfOK(mPDFWriter.ContinuePDFForStream(mWriteStreamProxy,inStateFilePath,inModifiedSourceStream.IsEmpty() ? NULL : mReadStreamProxy,inLogConfiguration));
 }
 
@@ -641,7 +641,7 @@ PDFHummus::EStatusCode PDFWriterDriver::ModifyPDF(const std::string& inSourceFil
 {
     // two phase, cause i don't want to bother the users with the level BS.
     // first, parse the source file, get the level. then modify with this level
-    
+
     mStartedWithStream = false;
     return setupListenerIfOK(mPDFWriter.ModifyPDF(inSourceFile,inPDFVersion,inOptionalOtherOutputFile,inLogConfiguration,inCreationSettings));
 }
@@ -653,10 +653,10 @@ PDFHummus::EStatusCode PDFWriterDriver::ModifyPDF(Local<Object> inSourceStream,
                                                   const PDFCreationSettings& inCreationSettings)
 {
     mStartedWithStream = true;
-   
+
     mWriteStreamProxy = new ObjectByteWriterWithPosition(inDestinationStream);
     mReadStreamProxy = new ObjectByteReaderWithPosition(inSourceStream);
-    
+
     // use minimal leve ePDFVersion10 to use the modified file level (cause i don't care
     return setupListenerIfOK(mPDFWriter.ModifyPDFForStream(mReadStreamProxy,mWriteStreamProxy,false,inPDFVersion,inLogConfiguration,inCreationSettings));
 }
@@ -665,28 +665,28 @@ METHOD_RETURN_TYPE PDFWriterDriver::CreateFormXObjectFromTIFF(const ARGS_TYPE& a
 {
     CREATE_ISOLATE_CONTEXT;
 	CREATE_ESCAPABLE_SCOPE;
-    
+
     if((args.Length() != 1 && args.Length() != 2) || (!args[0]->IsString() && !args[0]->IsObject()) || (args.Length() == 2 && !args[1]->IsObject() && !args[1]->IsNumber()))
     {
 		THROW_EXCEPTION("wrong arguments, pass 1 argument that is the path to the image, and optionally an options object or object ID");
 		SET_FUNCTION_RETURN_VALUE(UNDEFINED)
     }
-    
+
     PDFWriterDriver* pdfWriter = ObjectWrap::Unwrap<PDFWriterDriver>(args.This());
-    
+
     TIFFUsageParameters tiffUsageParameters = TIFFUsageParameters::DefaultTIFFUsageParameters();
     ObjectIDType objectID = 0;
-    
+
     if(args.Length() == 2)
     {
         if(args[1]->IsObject())
         {
             Local<Object> anObject = args[1]->TO_OBJECT();
-            
+
             // page index parameters
             if(anObject->Has(GET_CURRENT_CONTEXT, NEW_STRING("pageIndex")).FromJust() && anObject->Get(GET_CURRENT_CONTEXT, NEW_STRING("pageIndex")).ToLocalChecked()->IsNumber())
                 tiffUsageParameters.PageIndex = (unsigned int)TO_NUMBER(anObject->Get(GET_CURRENT_CONTEXT, NEW_STRING("pageIndex")).ToLocalChecked())->Value();
-            
+
             if(anObject->Has(GET_CURRENT_CONTEXT, NEW_STRING("bwTreatment")).FromJust() && anObject->Get(GET_CURRENT_CONTEXT, NEW_STRING("bwTreatment")).ToLocalChecked()->IsObject())
             {
                 // special black and white treatment
@@ -715,18 +715,18 @@ METHOD_RETURN_TYPE PDFWriterDriver::CreateFormXObjectFromTIFF(const ARGS_TYPE& a
         }
 
     }
-    
+
     PDFFormXObject* formXObject;
-    
+
     if(args[0]->IsObject())
     {
         ObjectByteReaderWithPosition proxy(args[0]->TO_OBJECT());
-        
+
         formXObject =
             objectID == 0 ?
                 pdfWriter->mPDFWriter.CreateFormXObjectFromTIFFStream(&proxy,tiffUsageParameters):
                 pdfWriter->mPDFWriter.CreateFormXObjectFromTIFFStream(&proxy,objectID,tiffUsageParameters);
-        
+
     }
     else
     {
@@ -740,7 +740,7 @@ METHOD_RETURN_TYPE PDFWriterDriver::CreateFormXObjectFromTIFF(const ARGS_TYPE& a
 		THROW_EXCEPTION("unable to create form xobject. verify that the target is an existing tiff file");
 		SET_FUNCTION_RETURN_VALUE(UNDEFINED)
     }
-    
+
     Local<Value> newInstance = pdfWriter->holder->GetNewFormXObject(args);
     ObjectWrap::Unwrap<FormXObjectDriver>(newInstance->TO_OBJECT())->FormXObject = formXObject;
     SET_FUNCTION_RETURN_VALUE(newInstance)
@@ -757,7 +757,7 @@ CMYKRGBColor PDFWriterDriver::colorFromArray(v8::Local<v8::Value> inArray)
                             (unsigned char)TO_NUMBER(inArray->TO_OBJECT()->Get(GET_CURRENT_CONTEXT, 1).ToLocalChecked())->Value(),
                             (unsigned char)TO_NUMBER(inArray->TO_OBJECT()->Get(GET_CURRENT_CONTEXT, 2).ToLocalChecked())->Value(),
                             (unsigned char)TO_NUMBER(inArray->TO_OBJECT()->Get(GET_CURRENT_CONTEXT, 3).ToLocalChecked())->Value());
-        
+
     }
     else if(inArray->TO_OBJECT()->Get(GET_CURRENT_CONTEXT, v8::NEW_STRING("length")).ToLocalChecked()->TO_UINT32Value() == 3)
     {
@@ -777,22 +777,22 @@ METHOD_RETURN_TYPE PDFWriterDriver::CreateImageXObjectFromJPG(const ARGS_TYPE& a
 {
     CREATE_ISOLATE_CONTEXT;
 	CREATE_ESCAPABLE_SCOPE;
-    
+
     if((args.Length() != 1 && args.Length() != 2) || (!args[0]->IsString() && !args[0]->IsObject()) || (args.Length() == 2 && !args[1]->IsNumber()))
     {
 		THROW_EXCEPTION("wrong arguments, pass 1 argument that is the path to the image. pass another optional argument of a forward reference object ID");
 		SET_FUNCTION_RETURN_VALUE(UNDEFINED)
     }
-    
+
     PDFWriterDriver* pdfWriter = ObjectWrap::Unwrap<PDFWriterDriver>(args.This());
-       
-   
+
+
     PDFImageXObject* imageXObject;
-    
+
     if(args[0]->IsObject())
     {
         ObjectByteReaderWithPosition proxy(args[0]->TO_OBJECT());
-        
+
         imageXObject =
             args.Length() == 2 ?
             pdfWriter->mPDFWriter.CreateImageXObjectFromJPGStream(&proxy,(ObjectIDType)TO_INT32(args[1])->Value()) :
@@ -810,7 +810,7 @@ METHOD_RETURN_TYPE PDFWriterDriver::CreateImageXObjectFromJPG(const ARGS_TYPE& a
 		THROW_EXCEPTION("unable to create image xobject. verify that the target is an existing jpg file");
 		SET_FUNCTION_RETURN_VALUE(UNDEFINED)
     }
-    
+
     Local<Value> newInstance = pdfWriter->holder->GetNewImageXObject(args);
     ObjectWrap::Unwrap<ImageXObjectDriver>(newInstance->TO_OBJECT())->ImageXObject = imageXObject;
     SET_FUNCTION_RETURN_VALUE(newInstance)
@@ -826,7 +826,7 @@ METHOD_RETURN_TYPE PDFWriterDriver::GetObjectsContext(const ARGS_TYPE& args)
     Local<Value> newInstance = pdfWriter->holder->GetNewObjectsContext(args);
     ObjectsContextDriver* objectsContextDriver = ObjectWrap::Unwrap<ObjectsContextDriver>(newInstance->TO_OBJECT());
     objectsContextDriver->ObjectsContextInstance = &(pdfWriter->mPDFWriter.GetObjectsContext());
- 
+
     SET_FUNCTION_RETURN_VALUE(newInstance)
 }
 
@@ -834,13 +834,13 @@ METHOD_RETURN_TYPE PDFWriterDriver::GetDocumentContext(const ARGS_TYPE& args)
 {
     CREATE_ISOLATE_CONTEXT;
 	CREATE_ESCAPABLE_SCOPE;
-    
+
     PDFWriterDriver* pdfWriter = ObjectWrap::Unwrap<PDFWriterDriver>(args.This());
-    
+
     Local<Value> newInstance = pdfWriter->holder->GetNewDocumentContext(args);
     DocumentContextDriver* documentContextDriver = ObjectWrap::Unwrap<DocumentContextDriver>(newInstance->TO_OBJECT());
     documentContextDriver->DocumentContextInstance = &(pdfWriter->mPDFWriter.GetDocumentContext());
-    
+
     SET_FUNCTION_RETURN_VALUE(newInstance)
 }
 
@@ -849,7 +849,7 @@ METHOD_RETURN_TYPE PDFWriterDriver::AppendPDFPagesFromPDF(const ARGS_TYPE& args)
 {
     CREATE_ISOLATE_CONTEXT;
 	CREATE_ESCAPABLE_SCOPE;
-    
+
     if( (args.Length() < 1  && args.Length() > 2) ||
         (!args[0]->IsString() && !args[0]->IsObject()) ||
         (args.Length() >= 2 && !args[1]->IsObject())
@@ -858,23 +858,23 @@ METHOD_RETURN_TYPE PDFWriterDriver::AppendPDFPagesFromPDF(const ARGS_TYPE& args)
 		THROW_EXCEPTION("wrong arguments, pass a path for file to append pages from or a stream object, optionally an options object");
 		SET_FUNCTION_RETURN_VALUE(UNDEFINED)
     }
-    
+
     PDFWriterDriver* pdfWriter = ObjectWrap::Unwrap<PDFWriterDriver>(args.This());
-    
+
     PDFPageRange pageRange;
     PDFParsingOptions parsingOptions;
-    
+
     if(args.Length() >= 2) {
         Local<Object> options = args[1]->TO_OBJECT();
         if(options->Has(GET_CURRENT_CONTEXT, NEW_STRING("password")).FromJust() && options->Get(GET_CURRENT_CONTEXT, NEW_STRING("password")).ToLocalChecked()->IsString())
         {
             parsingOptions.Password = *UTF_8_VALUE(options->Get(GET_CURRENT_CONTEXT, NEW_STRING("password")).ToLocalChecked()->TO_STRING());
-        }        
+        }
         pageRange = ObjectToPageRange(options);
     }
 
     EStatusCodeAndObjectIDTypeList result;
-    
+
     if(args[0]->IsObject())
     {
         ObjectByteReaderWithPosition proxy(args[0]->TO_OBJECT());
@@ -892,20 +892,20 @@ METHOD_RETURN_TYPE PDFWriterDriver::AppendPDFPagesFromPDF(const ARGS_TYPE& args)
                                                         ObjectIDTypeList(),
                                                         parsingOptions);
     }
-    
+
     if(result.first != eSuccess)
     {
 		THROW_EXCEPTION("unable to append page, make sure it's fine");
 		SET_FUNCTION_RETURN_VALUE(UNDEFINED)
     }
-    
+
     Local<Array> resultPageIDs = NEW_ARRAY((unsigned int)result.second.size());
     unsigned int index = 0;
-    
+
     ObjectIDTypeList::iterator it = result.second.begin();
     for(; it != result.second.end();++it)
         resultPageIDs->Set(GET_CURRENT_CONTEXT, NEW_NUMBER(index++),NEW_NUMBER(*it));
-    
+
     SET_FUNCTION_RETURN_VALUE(resultPageIDs)
 }
 
@@ -913,7 +913,7 @@ PDFPageRange PDFWriterDriver::ObjectToPageRange(Local<Object> inObject)
 {
 	CREATE_ISOLATE_CONTEXT;
 	PDFPageRange pageRange;
-        
+
     if(inObject->Has(GET_CURRENT_CONTEXT, NEW_STRING("type")).FromJust() && inObject->Get(GET_CURRENT_CONTEXT, NEW_STRING("type")).ToLocalChecked()->IsNumber())
     {
         pageRange.mType = (PDFPageRange::ERangeType)(TO_UINT32(inObject->Get(GET_CURRENT_CONTEXT, NEW_STRING("type")).ToLocalChecked())->Value());
@@ -940,10 +940,10 @@ PDFPageRange PDFWriterDriver::ObjectToPageRange(Local<Object> inObject)
             pageRange.mSpecificRanges.push_back(ULongAndULong(
                                                               TO_UINT32(item->Get(GET_CURRENT_CONTEXT, 0).ToLocalChecked())->Value(),
                                                               TO_UINT32(item->Get(GET_CURRENT_CONTEXT, 1).ToLocalChecked())->Value()));
-            
+
         }
     }
-    
+
     return pageRange;
 }
 
@@ -964,7 +964,7 @@ public:
         }
 		return PDFHummus::eSuccess;
 	}
-    
+
     bool IsValid(){return !callback.IsEmpty();}
 
     Local<Function> callback;
@@ -974,7 +974,7 @@ METHOD_RETURN_TYPE PDFWriterDriver::MergePDFPagesToPage(const ARGS_TYPE& args)
 {
     CREATE_ISOLATE_CONTEXT;
 	CREATE_ESCAPABLE_SCOPE;
-    
+
     /*
         parameters are:
             target page
@@ -982,7 +982,7 @@ METHOD_RETURN_TYPE PDFWriterDriver::MergePDFPagesToPage(const ARGS_TYPE& args)
             optional 1: options object
             optional 2: callback function to call after each page merge
      */
-    
+
     PDFWriterDriver* pdfWriter = ObjectWrap::Unwrap<PDFWriterDriver>(args.This());
 
     if(args.Length() < 2)
@@ -990,43 +990,43 @@ METHOD_RETURN_TYPE PDFWriterDriver::MergePDFPagesToPage(const ARGS_TYPE& args)
 		THROW_EXCEPTION("Too few arguments. Pass a page object, a path to pages source file or an IByteReaderWithPosition, and two optional: configuration object and callback function that will be called between pages merging");
 		SET_FUNCTION_RETURN_VALUE(UNDEFINED)
     }
-    
+
     if(!pdfWriter->holder->IsPDFPageInstance(args[0]))
     {
 		THROW_EXCEPTION("Invalid arguments. First argument must be a page object");
-		SET_FUNCTION_RETURN_VALUE(UNDEFINED)        
+		SET_FUNCTION_RETURN_VALUE(UNDEFINED)
     }
-    
-    if(!args[1]->IsString() && 
+
+    if(!args[1]->IsString() &&
        !args[1]->IsObject())
     {
 		THROW_EXCEPTION("Invalid arguments. Second argument must be either an input stream or a path to a pages source file.");
 		SET_FUNCTION_RETURN_VALUE(UNDEFINED)
     }
-    
+
     PDFPageDriver* page = ObjectWrap::Unwrap<PDFPageDriver>(args[0]->TO_OBJECT());
-    
+
     PDFPageRange pageRange;
-    PDFParsingOptions parsingOptions; 
-    
+    PDFParsingOptions parsingOptions;
+
     // get page range
     if(args.Length() > 2 && args[2]->IsObject()) {
         Local<Object> options = args[2]->TO_OBJECT();
         if(options->Has(GET_CURRENT_CONTEXT, NEW_STRING("password")).FromJust() && options->Get(GET_CURRENT_CONTEXT, NEW_STRING("password")).ToLocalChecked()->IsString())
         {
             parsingOptions.Password = *UTF_8_VALUE(options->Get(GET_CURRENT_CONTEXT, NEW_STRING("password")).ToLocalChecked()->TO_STRING());
-        }        
+        }
         pageRange = ObjectToPageRange(options);
-    } 
+    }
     else if(args.Length() > 3 && args[3]->IsObject()) {
         Local<Object> options = args[3]->TO_OBJECT();
         if(options->Has(GET_CURRENT_CONTEXT, NEW_STRING("password")).FromJust() && options->Get(GET_CURRENT_CONTEXT, NEW_STRING("password")).ToLocalChecked()->IsString())
         {
             parsingOptions.Password = *UTF_8_VALUE(options->Get(GET_CURRENT_CONTEXT, NEW_STRING("password")).ToLocalChecked()->TO_STRING());
-        }        
+        }
         pageRange = ObjectToPageRange(options);
     }
-    
+
     // now see if there's a need for activating the callback. will do that using the document extensibility option of the lib
     MergeInterpageCallbackCaller caller;
     if((args.Length() > 2 && args[2]->IsFunction()) ||
@@ -1034,9 +1034,9 @@ METHOD_RETURN_TYPE PDFWriterDriver::MergePDFPagesToPage(const ARGS_TYPE& args)
         caller.callback = Local<Function>::Cast(args[2]->IsFunction() ? args[2] : args[3]);
     if(caller.IsValid())
         pdfWriter->mPDFWriter.GetDocumentContext().AddDocumentContextExtender(&caller);
-    
+
     EStatusCode status;
-    if(args[1]->IsString()) 
+    if(args[1]->IsString())
     {
         status = pdfWriter->mPDFWriter.MergePDFPagesToPage(page->GetPage(),
                                                            *UTF_8_VALUE(args[1]->TO_STRING()),
@@ -1044,7 +1044,7 @@ METHOD_RETURN_TYPE PDFWriterDriver::MergePDFPagesToPage(const ARGS_TYPE& args)
                                                            ObjectIDTypeList(),
                                                            parsingOptions);
     }
-    else 
+    else
     {
 		ObjectByteReaderWithPosition proxy(args[1]->TO_OBJECT());
         status = pdfWriter->mPDFWriter.MergePDFPagesToPage(page->GetPage(),
@@ -1053,7 +1053,7 @@ METHOD_RETURN_TYPE PDFWriterDriver::MergePDFPagesToPage(const ARGS_TYPE& args)
                                                            ObjectIDTypeList(),
                                                            parsingOptions);
     }
-	
+
     if(caller.IsValid())
         pdfWriter->mPDFWriter.GetDocumentContext().RemoveDocumentContextExtender(&caller);
 
@@ -1069,7 +1069,7 @@ METHOD_RETURN_TYPE PDFWriterDriver::CreatePDFCopyingContext(const ARGS_TYPE& arg
 {
     CREATE_ISOLATE_CONTEXT;
 	CREATE_ESCAPABLE_SCOPE;
-    
+
     if( (args.Length() < 1  && args.Length() > 2) ||
         (!args[0]->IsString() && !args[0]->IsObject()) ||
         (args.Length() >= 2 && !args[1]->IsObject())
@@ -1078,7 +1078,7 @@ METHOD_RETURN_TYPE PDFWriterDriver::CreatePDFCopyingContext(const ARGS_TYPE& arg
 		THROW_EXCEPTION("wrong arguments, pass a path to a PDF file to create copying context for or a stream object, and then an optional options object");
 		SET_FUNCTION_RETURN_VALUE(UNDEFINED)
     }
-    
+
     PDFWriterDriver* pdfWriter = ObjectWrap::Unwrap<PDFWriterDriver>(args.This());
 
     PDFDocumentCopyingContext* copyingContext;
@@ -1091,10 +1091,10 @@ METHOD_RETURN_TYPE PDFWriterDriver::CreatePDFCopyingContext(const ARGS_TYPE& arg
         if(options->Has(GET_CURRENT_CONTEXT, NEW_STRING("password")).FromJust() && options->Get(GET_CURRENT_CONTEXT, NEW_STRING("password")).ToLocalChecked()->IsString())
         {
             parsingOptions.Password = *UTF_8_VALUE(options->Get(GET_CURRENT_CONTEXT, NEW_STRING("password")).ToLocalChecked()->TO_STRING());
-        }        
+        }
     }
 
-    
+
     if(args[0]->IsObject())
     {
         if(pdfWriter->holder->IsPDFReaderInstance(args[0]))
@@ -1117,13 +1117,13 @@ METHOD_RETURN_TYPE PDFWriterDriver::CreatePDFCopyingContext(const ARGS_TYPE& arg
         // file path based copying context
         copyingContext = pdfWriter->mPDFWriter.CreatePDFCopyingContext(*UTF_8_VALUE(args[0]->TO_STRING()),parsingOptions);
     }
-    
+
     if(!copyingContext)
     {
 		THROW_EXCEPTION("unable to create copying context. verify that the target is an existing PDF file");
 		SET_FUNCTION_RETURN_VALUE(UNDEFINED)
     }
-    
+
     Local<Value> newInstance = pdfWriter->holder->GetNewDocumentCopyingContext(args);
     ObjectWrap::Unwrap<DocumentCopyingContextDriver>(newInstance->TO_OBJECT())->CopyingContext = copyingContext;
     ObjectWrap::Unwrap<DocumentCopyingContextDriver>(newInstance->TO_OBJECT())->ReadStreamProxy = proxy;
@@ -1134,7 +1134,7 @@ METHOD_RETURN_TYPE PDFWriterDriver::CreateFormXObjectsFromPDF(const ARGS_TYPE& a
 {
     CREATE_ISOLATE_CONTEXT;
 	CREATE_ESCAPABLE_SCOPE;
-    
+
     if(args.Length() < 1  ||
        args.Length() > 5 ||
        !args[0]->IsString() ||
@@ -1147,12 +1147,12 @@ METHOD_RETURN_TYPE PDFWriterDriver::CreateFormXObjectsFromPDF(const ARGS_TYPE& a
 		THROW_EXCEPTION("wrong arguments, pass a path to the file, and optionals - a box enumerator or actual 4 numbers box, a range object, a matrix for the form, array of object ids to copy in addition");
 		SET_FUNCTION_RETURN_VALUE(UNDEFINED)
     }
-    
+
     PDFWriterDriver* pdfWriter = ObjectWrap::Unwrap<PDFWriterDriver>(args.This());
-    
+
     PDFPageRange pageRange;
     PDFParsingOptions parsingOptions;
-    
+
     if(args.Length() >= 3) {
         Local<Object> options = args[2]->TO_OBJECT();
         if(options->Has(GET_CURRENT_CONTEXT, NEW_STRING("password")).FromJust() && options->Get(GET_CURRENT_CONTEXT, NEW_STRING("password")).ToLocalChecked()->IsString())
@@ -1161,11 +1161,11 @@ METHOD_RETURN_TYPE PDFWriterDriver::CreateFormXObjectsFromPDF(const ARGS_TYPE& a
         }
         pageRange = ObjectToPageRange(options);
     }
-    
+
     EStatusCodeAndObjectIDTypeList result;
     double matrixBuffer[6];
     double* transformationMatrix = NULL;
-    
+
     if(args.Length() >= 4)
     {
         Local<Object> matrixArray = args[3]->TO_OBJECT();
@@ -1174,12 +1174,12 @@ METHOD_RETURN_TYPE PDFWriterDriver::CreateFormXObjectsFromPDF(const ARGS_TYPE& a
             THROW_EXCEPTION("matrix array should be 6 numbers long");
             SET_FUNCTION_RETURN_VALUE(UNDEFINED)
         }
-        
+
         for(int i=0;i<6;++i)
             matrixBuffer[i] = TO_NUMBER(matrixArray->Get(GET_CURRENT_CONTEXT, i).ToLocalChecked())->Value();
         transformationMatrix = matrixBuffer;
     }
-    
+
     ObjectIDTypeList extraObjectsList;
     if(args.Length() >= 5)
     {
@@ -1187,9 +1187,9 @@ METHOD_RETURN_TYPE PDFWriterDriver::CreateFormXObjectsFromPDF(const ARGS_TYPE& a
         unsigned int arrayLength = objectsIDsArray->Get(GET_CURRENT_CONTEXT, v8::NEW_STRING("length")).ToLocalChecked()->TO_UINT32Value();
         for(unsigned int i=0;i<arrayLength;++i)
             extraObjectsList.push_back((ObjectIDType)(TO_UINT32(objectsIDsArray->Get(GET_CURRENT_CONTEXT, i).ToLocalChecked())->Value()));
-            
+
     }
-    
+
     if(args[1]->IsArray())
     {
         Local<Object> boxArray = args[1]->TO_OBJECT();
@@ -1198,12 +1198,12 @@ METHOD_RETURN_TYPE PDFWriterDriver::CreateFormXObjectsFromPDF(const ARGS_TYPE& a
             THROW_EXCEPTION("box dimensions array should be 4 numbers long");
             SET_FUNCTION_RETURN_VALUE(UNDEFINED)
         }
-        
+
         PDFRectangle box(TO_NUMBER(boxArray->Get(GET_CURRENT_CONTEXT, 0).ToLocalChecked())->Value(),
                             TO_NUMBER(boxArray->Get(GET_CURRENT_CONTEXT, 1).ToLocalChecked())->Value(),
                             TO_NUMBER(boxArray->Get(GET_CURRENT_CONTEXT, 2).ToLocalChecked())->Value(),
                             TO_NUMBER(boxArray->Get(GET_CURRENT_CONTEXT, 3).ToLocalChecked())->Value());
-        
+
         result = pdfWriter->mPDFWriter.CreateFormXObjectsFromPDF(
                                                                  *UTF_8_VALUE(args[0]->TO_STRING()),
                                                                  pageRange,
@@ -1222,37 +1222,37 @@ METHOD_RETURN_TYPE PDFWriterDriver::CreateFormXObjectsFromPDF(const ARGS_TYPE& a
                                                                  extraObjectsList,
                                                                  parsingOptions);
     }
-    
+
     if(result.first != eSuccess)
     {
 		THROW_EXCEPTION("unable to create forms from file. make sure the file exists, and that the input page range is valid (well, if you provided one..m'k?");
 		SET_FUNCTION_RETURN_VALUE(UNDEFINED)
     }
-    
+
     Local<Array> resultFormIDs = NEW_ARRAY((unsigned int)result.second.size());
     unsigned int index = 0;
-    
+
     ObjectIDTypeList::iterator it = result.second.begin();
     for(; it != result.second.end();++it)
         resultFormIDs->Set(GET_CURRENT_CONTEXT, NEW_NUMBER(index++),NEW_NUMBER(*it));
-    
+
     SET_FUNCTION_RETURN_VALUE(resultFormIDs)
 }
- 
+
 METHOD_RETURN_TYPE PDFWriterDriver::CreatePDFCopyingContextForModifiedFile(const ARGS_TYPE& args)
 {
     CREATE_ISOLATE_CONTEXT;
 	CREATE_ESCAPABLE_SCOPE;
-    
+
     PDFWriterDriver* pdfWriter = ObjectWrap::Unwrap<PDFWriterDriver>(args.This());
-    
+
     PDFDocumentCopyingContext* copyingContext = pdfWriter->mPDFWriter.CreatePDFCopyingContextForModifiedFile();
     if(!copyingContext)
     {
 		THROW_EXCEPTION("unable to create copying context for modified file...possibly a file is not being modified by this writer...");
 		SET_FUNCTION_RETURN_VALUE(UNDEFINED)
     }
-    
+
     Local<Value> newInstance = pdfWriter->holder->GetNewDocumentCopyingContext(args);
     ObjectWrap::Unwrap<DocumentCopyingContextDriver>(newInstance->TO_OBJECT())->CopyingContext = copyingContext;
     SET_FUNCTION_RETURN_VALUE(newInstance)
@@ -1265,7 +1265,7 @@ METHOD_RETURN_TYPE PDFWriterDriver::CreatePDFTextString(const ARGS_TYPE& args)
     PDFWriterDriver* pdfWriter = ObjectWrap::Unwrap<PDFWriterDriver>(args.This());
 
     SET_FUNCTION_RETURN_VALUE(pdfWriter->holder->GetNewPDFTextString(args))
-    
+
 }
 
 METHOD_RETURN_TYPE PDFWriterDriver::CreatePDFDate(const ARGS_TYPE& args)
@@ -1275,7 +1275,7 @@ METHOD_RETURN_TYPE PDFWriterDriver::CreatePDFDate(const ARGS_TYPE& args)
     PDFWriterDriver* pdfWriter = ObjectWrap::Unwrap<PDFWriterDriver>(args.This());
 
     SET_FUNCTION_RETURN_VALUE(pdfWriter->holder->GetNewPDFDate(args))
-    
+
 }
 
 PDFWriter* PDFWriterDriver::GetWriter()
@@ -1287,17 +1287,17 @@ METHOD_RETURN_TYPE PDFWriterDriver::GetImageDimensions(const ARGS_TYPE& args)
 {
     CREATE_ISOLATE_CONTEXT;
 	CREATE_ESCAPABLE_SCOPE;
-    
+
     if(args.Length() < 1 || args.Length() > 3 ||
-       !args[0]->IsString() ||
+       (!args[0]->IsString() && !args[0]->IsObject()) ||
        (args.Length()>=2 && !args[1]->IsNumber()) ||
        (args.Length() >= 3 && !args[2]->IsObject())
        )
     {
-		THROW_EXCEPTION("wrong arguments, pass 1 to 3 arguments. a path to an image, an optional image index (for multi-image files), and an options object");
+		THROW_EXCEPTION("wrong arguments, pass 1 to 3 arguments. a path to an image or a stream object, an optional image index (for multi-image files), and an options object");
 		SET_FUNCTION_RETURN_VALUE(UNDEFINED)
     }
-    
+
     PDFWriterDriver* pdfWriter = ObjectWrap::Unwrap<PDFWriterDriver>(args.This());
 
     PDFParsingOptions parsingOptions;
@@ -1307,16 +1307,28 @@ METHOD_RETURN_TYPE PDFWriterDriver::GetImageDimensions(const ARGS_TYPE& args)
         if(options->Has(GET_CURRENT_CONTEXT, NEW_STRING("password")).FromJust() && options->Get(GET_CURRENT_CONTEXT, NEW_STRING("password")).ToLocalChecked()->IsString())
         {
             parsingOptions.Password = *UTF_8_VALUE(options->Get(GET_CURRENT_CONTEXT, NEW_STRING("password")).ToLocalChecked()->TO_STRING());
-        }        
+        }
     }
 
-    DoubleAndDoublePair dimensions = pdfWriter->mPDFWriter.GetImageDimensions(
-                                  *UTF_8_VALUE(args[0]->TO_STRING()),
-                                  args.Length() >= 2 ? TO_UINT32(args[1])->Value() : 0,
-                                  parsingOptions);
-    
+    DoubleAndDoublePair dimensions;
+
+    if(args[0]->IsObject())
+    {
+      ObjectByteReaderWithPosition proxy(args[0]->TO_OBJECT());
+
+      dimensions = pdfWriter->mPDFWriter.GetImageDimensions(&proxy,
+                                                            args.Length() >= 2 ? TO_UINT32(args[1])->Value() : 0,
+                                                            parsingOptions);
+    }
+    else
+    {
+      dimensions = pdfWriter->mPDFWriter.GetImageDimensions(*UTF_8_VALUE(args[0]->TO_STRING()),
+                                                            args.Length() >= 2 ? TO_UINT32(args[1])->Value() : 0,
+                                                            parsingOptions);
+    }
+
     Local<Object> newObject = NEW_OBJECT;
-    
+
     newObject->Set(GET_CURRENT_CONTEXT, NEW_SYMBOL("width"),NEW_NUMBER(dimensions.first));
     newObject->Set(GET_CURRENT_CONTEXT, NEW_SYMBOL("height"),NEW_NUMBER(dimensions.second));
     SET_FUNCTION_RETURN_VALUE(newObject)
@@ -1345,8 +1357,8 @@ METHOD_RETURN_TYPE PDFWriterDriver::GetImagePagesCount(const ARGS_TYPE& args)
         if(options->Has(GET_CURRENT_CONTEXT, NEW_STRING("password")).FromJust() && options->Get(GET_CURRENT_CONTEXT, NEW_STRING("password")).ToLocalChecked()->IsString())
         {
             parsingOptions.Password = *UTF_8_VALUE(options->Get(GET_CURRENT_CONTEXT, NEW_STRING("password")).ToLocalChecked()->TO_STRING());
-        }        
-    }    
+        }
+    }
 
 	unsigned long result = pdfWriter->mPDFWriter.GetImagePagesCount(*UTF_8_VALUE(args[0]->TO_STRING()),parsingOptions);
 
@@ -1360,14 +1372,14 @@ METHOD_RETURN_TYPE PDFWriterDriver::GetImageType(const ARGS_TYPE& args) {
 	if (args.Length() != 1 ||
 		!args[0]->IsString())
 	{
-		THROW_EXCEPTION("wrong arguments, pass 1 argument. a path to an imag");
+		THROW_EXCEPTION("wrong arguments, pass 1 argument. a path to an image");
 		SET_FUNCTION_RETURN_VALUE(UNDEFINED)
 	}
 
 	PDFWriterDriver* pdfWriter = ObjectWrap::Unwrap<PDFWriterDriver>(args.This());
 
     PDFHummus::EHummusImageType imageType = pdfWriter->mPDFWriter.GetImageType(*UTF_8_VALUE(args[0]->TO_STRING()),0);
-        
+
     switch(imageType)
     {
         case PDFHummus::ePDF:
@@ -1392,7 +1404,7 @@ METHOD_RETURN_TYPE PDFWriterDriver::GetImageType(const ARGS_TYPE& args) {
         }
         default:
         {
-            SET_FUNCTION_RETURN_VALUE(UNDEFINED)    
+            SET_FUNCTION_RETURN_VALUE(UNDEFINED)
         }
     }
 }
@@ -1401,16 +1413,16 @@ METHOD_RETURN_TYPE PDFWriterDriver::GetModifiedFileParser(const ARGS_TYPE& args)
 {
     CREATE_ISOLATE_CONTEXT;
 	CREATE_ESCAPABLE_SCOPE;
-    
+
     PDFWriterDriver* pdfWriter = ObjectWrap::Unwrap<PDFWriterDriver>(args.This());
-    
+
     PDFParser* parser = &(pdfWriter->mPDFWriter.GetModifiedFileParser());
     if(!parser->GetTrailer()) // checking for the trailer should be a good indication to whether this parser is relevant
     {
 		THROW_EXCEPTION("unable to create modified parser...possibly a file is not being modified by this writer...");
 		SET_FUNCTION_RETURN_VALUE(UNDEFINED)
     }
-    
+
     Local<Value> newInstance = pdfWriter->holder->GetNewPDFReader(args);
     ObjectWrap::Unwrap<PDFReaderDriver>(newInstance->TO_OBJECT())->SetFromOwnedParser(parser);
     SET_FUNCTION_RETURN_VALUE(newInstance)
@@ -1420,16 +1432,16 @@ METHOD_RETURN_TYPE PDFWriterDriver::GetModifiedInputFile(const ARGS_TYPE& args)
 {
     CREATE_ISOLATE_CONTEXT;
 	CREATE_ESCAPABLE_SCOPE;
-    
+
     PDFWriterDriver* pdfWriter = ObjectWrap::Unwrap<PDFWriterDriver>(args.This());
-    
+
     InputFile* inputFile = &(pdfWriter->mPDFWriter.GetModifiedInputFile());
-    if(!inputFile->GetInputStream()) 
+    if(!inputFile->GetInputStream())
     {
 		THROW_EXCEPTION("unable to create modified input file...possibly a file is not being modified by this writer...");
 		SET_FUNCTION_RETURN_VALUE(UNDEFINED)
     }
-    
+
     Local<Value> newInstance = pdfWriter->holder->GetNewInputFile(args);
     ObjectWrap::Unwrap<InputFileDriver>(newInstance->TO_OBJECT())->SetFromOwnedFile(inputFile);
     SET_FUNCTION_RETURN_VALUE(newInstance)
@@ -1439,16 +1451,16 @@ METHOD_RETURN_TYPE PDFWriterDriver::GetOutputFile(const ARGS_TYPE& args)
 {
     CREATE_ISOLATE_CONTEXT;
 	CREATE_ESCAPABLE_SCOPE;
-    
+
     PDFWriterDriver* pdfWriter = ObjectWrap::Unwrap<PDFWriterDriver>(args.This());
-    
+
     OutputFile* outputFile = &(pdfWriter->mPDFWriter.GetOutputFile());
     if(!outputFile->GetOutputStream())
     {
 		THROW_EXCEPTION("unable to get output file. probably pdf writing hasn't started, or the output is not to a file");
 		SET_FUNCTION_RETURN_VALUE(UNDEFINED)
     }
-    
+
     Local<Value> newInstance = pdfWriter->holder->GetNewOutputFile(args);
     ObjectWrap::Unwrap<OutputFileDriver>(newInstance->TO_OBJECT())->SetFromOwnedFile(outputFile);
     SET_FUNCTION_RETURN_VALUE(newInstance)
@@ -1467,7 +1479,7 @@ METHOD_RETURN_TYPE PDFWriterDriver::RegisterAnnotationReferenceForNextPageWrite(
     }
 
     PDFWriterDriver* pdfWriter = ObjectWrap::Unwrap<PDFWriterDriver>(args.This());
-    
+
     pdfWriter->mPDFWriter.GetDocumentContext().RegisterAnnotationReferenceForNextPageWrite(TO_UINT32(args[0])->Value());
 
     SET_FUNCTION_RETURN_VALUE(args.This())
@@ -1488,7 +1500,7 @@ METHOD_RETURN_TYPE PDFWriterDriver::RequireCatalogUpdate(const ARGS_TYPE& args)
 /*
     From now on, extensions event triggers.
     got the following events for now:
-    
+
     OnPageWrite: {
                     page:PDFPage,
                     pageDictionaryContext:DictionaryContext
@@ -1499,7 +1511,7 @@ METHOD_RETURN_TYPE PDFWriterDriver::RequireCatalogUpdate(const ARGS_TYPE& args)
     }
     OnResourceDictionaryWrite {
                 resourceDictionaryName: string
-                resourceDictionary: DictionaryContext	
+                resourceDictionary: DictionaryContext
     }
     OnCatalogWrite {
                 catalogDictionaryContext: DictionaryContext
@@ -1518,7 +1530,7 @@ PDFHummus::EStatusCode PDFWriterDriver::OnPageWrite(
 
 	params->Set(GET_CURRENT_CONTEXT, NEW_SYMBOL("page"),this->holder->GetInstanceFor(inPage));
 	params->Set(GET_CURRENT_CONTEXT, NEW_SYMBOL("pageDictionaryContext"), this->holder->GetInstanceFor(inPageDictionaryContext));
-    return triggerEvent("OnPageWrite",params);        
+    return triggerEvent("OnPageWrite",params);
 }
 PDFHummus::EStatusCode PDFWriterDriver::OnResourcesWrite(
                         ResourcesDictionary* inResources,
@@ -1532,7 +1544,7 @@ PDFHummus::EStatusCode PDFWriterDriver::OnResourcesWrite(
 
 	params->Set(GET_CURRENT_CONTEXT, NEW_SYMBOL("resources"),this->holder->GetInstanceFor(inResources));
 	params->Set(GET_CURRENT_CONTEXT, NEW_SYMBOL("pageResourcesDictionaryContext"),this->holder->GetInstanceFor(inPageResourcesDictionaryContext));
-    return triggerEvent("OnResourcesWrite",params);        
+    return triggerEvent("OnResourcesWrite",params);
 }
 
 PDFHummus::EStatusCode PDFWriterDriver::OnResourceDictionaryWrite(
@@ -1547,7 +1559,7 @@ PDFHummus::EStatusCode PDFWriterDriver::OnResourceDictionaryWrite(
 
 	params->Set(GET_CURRENT_CONTEXT, NEW_SYMBOL("resourceDictionaryName"),NEW_STRING(inResourceDictionaryName.c_str()));
 	params->Set(GET_CURRENT_CONTEXT, NEW_SYMBOL("resourceDictionary"),this->holder->GetInstanceFor(inResourceDictionary));
-    return triggerEvent("OnResourceDictionaryWrite",params);        
+    return triggerEvent("OnResourceDictionaryWrite",params);
 }
 
 PDFHummus::EStatusCode PDFWriterDriver::OnFormXObjectWrite(
@@ -1556,8 +1568,8 @@ PDFHummus::EStatusCode PDFWriterDriver::OnFormXObjectWrite(
                         DictionaryContext* inFormDictionaryContext,
                         ObjectsContext* inPDFWriterObjectContext,
                         PDFHummus::DocumentContext* inDocumentContext) {
-                            
-    return PDFHummus::eSuccess;                               
+
+    return PDFHummus::eSuccess;
 }
 PDFHummus::EStatusCode PDFWriterDriver::OnJPEGImageXObjectWrite(
                         ObjectIDType inImageXObjectID,
@@ -1565,8 +1577,8 @@ PDFHummus::EStatusCode PDFWriterDriver::OnJPEGImageXObjectWrite(
                         ObjectsContext* inPDFWriterObjectContext,
                         PDFHummus::DocumentContext* inDocumentContext,
                         JPEGImageHandler* inJPGImageHandler) {
-                            
-    return PDFHummus::eSuccess;                               
+
+    return PDFHummus::eSuccess;
 }
 PDFHummus::EStatusCode PDFWriterDriver::OnTIFFImageXObjectWrite(
                         ObjectIDType inImageXObjectID,
@@ -1574,8 +1586,8 @@ PDFHummus::EStatusCode PDFWriterDriver::OnTIFFImageXObjectWrite(
                         ObjectsContext* inPDFWriterObjectContext,
                         PDFHummus::DocumentContext* inDocumentContext,
                         TIFFImageHandler* inTIFFImageHandler) {
-                            
-    return PDFHummus::eSuccess;                               
+
+    return PDFHummus::eSuccess;
 }
 
 PDFHummus::EStatusCode PDFWriterDriver::triggerEvent(const std::string& inEventName, v8::Local<v8::Object> inParams) {
@@ -1589,8 +1601,8 @@ PDFHummus::EStatusCode PDFWriterDriver::triggerEvent(const std::string& inEventN
     Local<Value> args[2];
     args[0] = NEW_STRING(inEventName.c_str());
     args[1] = inParams;
-	func->Call(GET_CURRENT_CONTEXT, THIS_HANDLE, 2, args).ToLocalChecked();                
-    return PDFHummus::eSuccess; 
+	func->Call(GET_CURRENT_CONTEXT, THIS_HANDLE, 2, args).ToLocalChecked();
+    return PDFHummus::eSuccess;
 }
 
 
@@ -1606,7 +1618,7 @@ PDFHummus::EStatusCode PDFWriterDriver::OnCatalogWrite(
 
     // this is the only important one
 	params->Set(GET_CURRENT_CONTEXT, NEW_SYMBOL("catalogDictionaryContext"),this->holder->GetInstanceFor(inCatalogDictionaryContext));
-    return triggerEvent("OnCatalogWrite",params);                               
+    return triggerEvent("OnCatalogWrite",params);
 }
 
 
@@ -1614,16 +1626,16 @@ PDFHummus::EStatusCode PDFWriterDriver::OnPDFParsingComplete(
                         ObjectsContext* inPDFWriterObjectContext,
                         PDFHummus::DocumentContext* inDocumentContext,
                         PDFDocumentHandler* inPDFDocumentHandler) {
-                            
-    return PDFHummus::eSuccess;                               
+
+    return PDFHummus::eSuccess;
 }
 PDFHummus::EStatusCode PDFWriterDriver::OnBeforeCreateXObjectFromPage(
                         PDFDictionary* inPageObjectDictionary,
                         ObjectsContext* inPDFWriterObjectContext,
                         PDFHummus::DocumentContext* inDocumentContext,
                         PDFDocumentHandler* inPDFDocumentHandler) {
-                            
-    return PDFHummus::eSuccess;                               
+
+    return PDFHummus::eSuccess;
 }
 PDFHummus::EStatusCode PDFWriterDriver::OnAfterCreateXObjectFromPage(
                         PDFFormXObject* iPageObjectResultXObject,
@@ -1631,16 +1643,16 @@ PDFHummus::EStatusCode PDFWriterDriver::OnAfterCreateXObjectFromPage(
                         ObjectsContext* inPDFWriterObjectContext,
                         PDFHummus::DocumentContext* inDocumentContext,
                         PDFDocumentHandler* inPDFDocumentHandler) {
-                            
-    return PDFHummus::eSuccess;                               
+
+    return PDFHummus::eSuccess;
 }
 PDFHummus::EStatusCode PDFWriterDriver::OnBeforeCreatePageFromPage(
                         PDFDictionary* inPageObjectDictionary,
                         ObjectsContext* inPDFWriterObjectContext,
                         PDFHummus::DocumentContext* inDocumentContext,
                         PDFDocumentHandler* inPDFDocumentHandler) {
-                            
-    return PDFHummus::eSuccess;                               
+
+    return PDFHummus::eSuccess;
 }
 PDFHummus::EStatusCode PDFWriterDriver::OnAfterCreatePageFromPage(
                         PDFPage* iPageObjectResultPage,
@@ -1648,8 +1660,8 @@ PDFHummus::EStatusCode PDFWriterDriver::OnAfterCreatePageFromPage(
                         ObjectsContext* inPDFWriterObjectContext,
                         PDFHummus::DocumentContext* inDocumentContext,
                         PDFDocumentHandler* inPDFDocumentHandler) {
-                            
-    return PDFHummus::eSuccess;                               
+
+    return PDFHummus::eSuccess;
 }
 PDFHummus::EStatusCode PDFWriterDriver::OnBeforeMergePageFromPage(
                         PDFPage* inTargetPage,
@@ -1657,8 +1669,8 @@ PDFHummus::EStatusCode PDFWriterDriver::OnBeforeMergePageFromPage(
                         ObjectsContext* inPDFWriterObjectContext,
                         PDFHummus::DocumentContext* inDocumentContext,
                         PDFDocumentHandler* inPDFDocumentHandler) {
-                            
-    return PDFHummus::eSuccess;                               
+
+    return PDFHummus::eSuccess;
 }
 PDFHummus::EStatusCode PDFWriterDriver::OnAfterMergePageFromPage(
                         PDFPage* inTargetPage,
@@ -1666,18 +1678,18 @@ PDFHummus::EStatusCode PDFWriterDriver::OnAfterMergePageFromPage(
                         ObjectsContext* inPDFWriterObjectContext,
                         PDFHummus::DocumentContext* inDocumentContext,
                         PDFDocumentHandler* inPDFDocumentHandler) {
-                            
-    return PDFHummus::eSuccess;                               
+
+    return PDFHummus::eSuccess;
 }
 PDFHummus::EStatusCode PDFWriterDriver::OnPDFCopyingComplete(
                         ObjectsContext* inPDFWriterObjectContext,
                         PDFHummus::DocumentContext* inDocumentContext,
                         PDFDocumentHandler* inPDFDocumentHandler) {
-                 
-    return PDFHummus::eSuccess;                               
+
+    return PDFHummus::eSuccess;
 }
 bool PDFWriterDriver::IsCatalogUpdateRequiredForModifiedFile(PDFParser* inModifiderFileParser) {
-    
+
     return mIsCatalogUpdateRequired;
 }
 

--- a/src/deps/PDFWriter/DocumentContext.cpp
+++ b/src/deps/PDFWriter/DocumentContext.cpp
@@ -2905,7 +2905,7 @@ static const Byte scMagicPng[] = { 0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0
 
 PDFHummus::EHummusImageType DocumentContext::GetImageType(IByteReaderWithPosition* inImageStream,unsigned long inImageIndex)
 {
-	// The types of images that are discovered here are those familiar to Hummus - JPG, TIFF and PDF
+	// The types of images that are discovered here are those familiar to Hummus - JPG, TIFF and PDF.
 	// PDF is recognized by starting with "%PDF"
 	// JPG will start with "0xff,0xd8"
 	// TIFF will start with "0x49,0x49" (little endian) or "0x4D,0x4D" (big endian)

--- a/src/deps/PDFWriter/DocumentContext.cpp
+++ b/src/deps/PDFWriter/DocumentContext.cpp
@@ -16,7 +16,7 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 
-   
+
 */
 #include "DocumentContext.h"
 #include "ObjectsContext.h"
@@ -225,7 +225,7 @@ EStatusCode	DocumentContext::FinalizeNewPDF()
 
 		WriteXrefReference(xrefTablePosition);
 		WriteFinalEOF();
-		
+
 	} while(false);
 
 	return status;
@@ -239,7 +239,7 @@ void DocumentContext::WriteXrefReference(LongFilePositionType inXrefTablePositio
 	mObjectsContext->WriteInteger(inXrefTablePosition,eTokenSeparatorEndLine);
 }
 
-static const IOBasicTypes::Byte scEOF[] = {'%','%','E','O','F'}; 
+static const IOBasicTypes::Byte scEOF[] = {'%','%','E','O','F'};
 
 void DocumentContext::WriteFinalEOF()
 {
@@ -258,12 +258,12 @@ static const std::string scID = "ID";
 EStatusCode DocumentContext::WriteTrailerDictionary()
 {
 	DictionaryContext* dictionaryContext;
-    
+
 	mObjectsContext->WriteKeyword(scTrailer);
 	dictionaryContext = mObjectsContext->StartDictionary();
 
     EStatusCode status = WriteTrailerDictionaryValues(dictionaryContext);
-    
+
     mObjectsContext->EndDictionary(dictionaryContext);
 
     return status;
@@ -275,13 +275,13 @@ EStatusCode DocumentContext::WriteTrailerDictionaryValues(DictionaryContext* inD
 
 	do
 	{
-	
+
 		// size
 		inDictionaryContext->WriteKey(scSize);
 		inDictionaryContext->WriteIntegerValue(mObjectsContext->GetInDirectObjectsRegistry().GetObjectsCount());
 
 		// prev reference
-		BoolAndLongFilePositionType filePositionResult = mTrailerInformation.GetPrev(); 
+		BoolAndLongFilePositionType filePositionResult = mTrailerInformation.GetPrev();
 		if(filePositionResult.first)
 		{
 			inDictionaryContext->WriteKey(scPrev);
@@ -325,7 +325,7 @@ EStatusCode DocumentContext::WriteTrailerDictionaryValues(DictionaryContext* inD
 			mNewPDFID = GenerateMD5IDForFile();
 		inDictionaryContext->WriteKey(scID);
 		mObjectsContext->StartArray();
-        
+
         // if modified file scenario use original ID, otherwise create a new one for the document created ID
         if(mModifiedDocumentIDExists)
             mObjectsContext->WriteHexString(mModifiedDocumentID);
@@ -338,7 +338,7 @@ EStatusCode DocumentContext::WriteTrailerDictionaryValues(DictionaryContext* inD
 		mEncryptionHelper.ReleaseEncryption();
 
 	}while(false);
-	
+
 	return status;
 }
 
@@ -365,49 +365,49 @@ void DocumentContext::WriteInfoDictionary()
 
 	mTrailerInformation.SetInfoDictionaryReference(infoDictionaryID);
 
-	if(!infoDictionary.Title.IsEmpty()) 
+	if(!infoDictionary.Title.IsEmpty())
 	{
 		infoContext->WriteKey(scTitle);
 		infoContext->WriteLiteralStringValue(infoDictionary.Title.ToString());
 	}
-	
-	if(!infoDictionary.Author.IsEmpty()) 
+
+	if(!infoDictionary.Author.IsEmpty())
 	{
 		infoContext->WriteKey(scAuthor);
 		infoContext->WriteLiteralStringValue(infoDictionary.Author.ToString());
 	}
 
-	if(!infoDictionary.Subject.IsEmpty()) 
+	if(!infoDictionary.Subject.IsEmpty())
 	{
 		infoContext->WriteKey(scSubject);
 		infoContext->WriteLiteralStringValue(infoDictionary.Subject.ToString());
 	}
 
-	if(!infoDictionary.Keywords.IsEmpty()) 
+	if(!infoDictionary.Keywords.IsEmpty())
 	{
 		infoContext->WriteKey(scKeywords);
 		infoContext->WriteLiteralStringValue(infoDictionary.Keywords.ToString());
 	}
 
-	if(!infoDictionary.Creator.IsEmpty()) 
+	if(!infoDictionary.Creator.IsEmpty())
 	{
 		infoContext->WriteKey(scCreator);
 		infoContext->WriteLiteralStringValue(infoDictionary.Creator.ToString());
 	}
 
-	if(!infoDictionary.Producer.IsEmpty()) 
+	if(!infoDictionary.Producer.IsEmpty())
 	{
 		infoContext->WriteKey(scProducer);
 		infoContext->WriteLiteralStringValue(infoDictionary.Producer.ToString());
 	}
 
-	if(!infoDictionary.CreationDate.IsNull()) 
+	if(!infoDictionary.CreationDate.IsNull())
 	{
 		infoContext->WriteKey(scCreationDate);
 		infoContext->WriteLiteralStringValue(infoDictionary.CreationDate.ToString());
 	}
 
-	if(!infoDictionary.ModDate.IsNull()) 
+	if(!infoDictionary.ModDate.IsNull())
 	{
 		infoContext->WriteKey(scModDate);
 		infoContext->WriteLiteralStringValue(infoDictionary.ModDate.ToString());
@@ -429,7 +429,7 @@ void DocumentContext::WriteInfoDictionary()
 
 	mObjectsContext->EndDictionary(infoContext);
 	mObjectsContext->EndIndirectObject();
-	
+
 }
 
 void DocumentContext::WriteEncryptionDictionary() {
@@ -490,7 +490,7 @@ static const std::string scPages = "Pages";
 EStatusCode DocumentContext::WriteCatalogObjectOfNewPDF()
 {
     return WriteCatalogObject(DocumentHasNewPages() ? mCatalogInformation.GetPageTreeRoot(mObjectsContext->GetInDirectObjectsRegistry())->GetID(): ObjectReference());
-    
+
 }
 
 EStatusCode DocumentContext::WriteCatalogObject(const ObjectReference& inPageTreeRootObjectReference,IDocumentContextExtender* inModifiedFileCopyContext)
@@ -516,13 +516,13 @@ EStatusCode DocumentContext::WriteCatalogObject(const ObjectReference& inPageTre
 		if(status != PDFHummus::eSuccess)
 			TRACE_LOG("DocumentContext::WriteCatalogObject, unexpected failure. extender declared failure when writing catalog.");
 	}
-	
+
 	if (inModifiedFileCopyContext){
 		status = inModifiedFileCopyContext->OnCatalogWrite(&mCatalogInformation,catalogContext,mObjectsContext,this);
 		if(status != PDFHummus::eSuccess)
 			TRACE_LOG("DocumentContext::WriteCatalogObject, unexpected failure. Copying extender declared failure when writing catalog.");
 	}
-	
+
 	mObjectsContext->EndDictionary(catalogContext);
 	mObjectsContext->EndIndirectObject();
 	return status;
@@ -555,7 +555,7 @@ int DocumentContext::WritePageTree(PageTree* inPageTreeToWrite)
 		// type
 		pagesTreeContext->WriteKey(scType);
 		pagesTreeContext->WriteNameValue(scPages);
-		
+
 		// count
 		pagesTreeContext->WriteKey(scCount);
 		pagesTreeContext->WriteIntegerValue(inPageTreeToWrite->GetNodesCount());
@@ -595,7 +595,7 @@ int DocumentContext::WritePageTree(PageTree* inPageTreeToWrite)
 		// type
 		pagesTreeContext->WriteKey(scType);
 		pagesTreeContext->WriteNameValue(scPages);
-		
+
 		// count
 		pagesTreeContext->WriteKey(scCount);
 		pagesTreeContext->WriteIntegerValue(totalPagesNodes);
@@ -635,7 +635,7 @@ static const std::string scContents = "Contents";
 EStatusCodeAndObjectIDType DocumentContext::WritePage(PDFPage* inPage)
 {
 	EStatusCodeAndObjectIDType result;
-	
+
 	result.first = PDFHummus::eSuccess;
 	result.second = mObjectsContext->StartNewIndirectObject();
 
@@ -648,7 +648,7 @@ EStatusCodeAndObjectIDType DocumentContext::WritePage(PDFPage* inPage)
 	// parent
 	pageContext->WriteKey(scParent);
 	pageContext->WriteNewObjectReferenceValue(mCatalogInformation.AddPageToPageTree(result.second,mObjectsContext->GetInDirectObjectsRegistry()));
-	
+
 	// Media Box
 	pageContext->WriteKey(scMediaBox);
 	pageContext->WriteRectangleValue(inPage->GetMediaBox());
@@ -668,35 +668,35 @@ EStatusCodeAndObjectIDType DocumentContext::WritePage(PDFPage* inPage)
         pageContext->WriteRectangleValue(inPage->GetCropBox().second);
         cropBox = inPage->GetCropBox().second;
     }
-    else 
+    else
         cropBox = inPage->GetMediaBox();
-    
-    
+
+
     // Bleed Box
     if(inPage->GetBleedBox().first && (inPage->GetBleedBox().second != cropBox))
     {
         pageContext->WriteKey(scBleedBox);
         pageContext->WriteRectangleValue(inPage->GetBleedBox().second);
     }
-    
+
     // Trim Box
     if(inPage->GetTrimBox().first && (inPage->GetTrimBox().second != cropBox))
     {
         pageContext->WriteKey(scTrimBox);
         pageContext->WriteRectangleValue(inPage->GetTrimBox().second);
-    }    
-    
+    }
+
     // Art Box
     if(inPage->GetArtBox().first && (inPage->GetArtBox().second != cropBox))
     {
         pageContext->WriteKey(scArtBox);
         pageContext->WriteRectangleValue(inPage->GetArtBox().second);
-    }    
-    
-    
+    }
+
+
 	do
 	{
-		// Resource dict 
+		// Resource dict
 		pageContext->WriteKey(scResources);
 		result.first = WriteResourcesDictionary(inPage->GetResourcesDictionary());
 		if(result.first != PDFHummus::eSuccess)
@@ -715,7 +715,7 @@ EStatusCodeAndObjectIDType DocumentContext::WritePage(PDFPage* inPage)
 			mObjectsContext->StartArray();
 			for(; it != mAnnotations.end(); ++it)
 				mObjectsContext->WriteNewIndirectObjectReference(*it);
-			mObjectsContext->EndArray(eTokenSeparatorEndLine);			
+			mObjectsContext->EndArray(eTokenSeparatorEndLine);
 		}
 		mAnnotations.clear();
 
@@ -730,7 +730,7 @@ EStatusCodeAndObjectIDType DocumentContext::WritePage(PDFPage* inPage)
 				mObjectsContext->StartArray();
 				while(iterator.MoveNext())
 					mObjectsContext->WriteNewIndirectObjectReference(iterator.GetItem());
-				mObjectsContext->EndArray();	
+				mObjectsContext->EndArray();
 				mObjectsContext->EndLine();
 			}
 			else
@@ -757,24 +757,24 @@ EStatusCodeAndObjectIDType DocumentContext::WritePage(PDFPage* inPage)
 			break;
 		}
 		mObjectsContext->EndIndirectObject();
-        
+
         // now write writing tasks
         PDFPageToIPageEndWritingTaskListMap::iterator itPageTasks= mPageEndTasks.find(inPage);
-        
+
         result.first = eSuccess;
         if(itPageTasks != mPageEndTasks.end())
         {
             IPageEndWritingTaskList::iterator itTasks = itPageTasks->second.begin();
-            
+
             for(; itTasks != itPageTasks->second.end() && eSuccess == result.first; ++itTasks)
                 result.first = (*itTasks)->Write(inPage,mObjectsContext,this);
-            
+
             // one time, so delete
             for(itTasks = itPageTasks->second.begin(); itTasks != itPageTasks->second.end(); ++itTasks)
                 delete (*itTasks);
             mPageEndTasks.erase(itPageTasks);
         }
-        
+
 	}while(false);
 
 	return result;
@@ -914,7 +914,7 @@ PDFTiledPattern* DocumentContext::StartTiledPattern(
 			mObjectsContext->EndArray(eTokenSeparatorEndLine);
 		}
 
-		// Resource dict 
+		// Resource dict
 		context->WriteKey(scResources);
 		// put a resources dictionary place holder
 		ObjectIDType resourcesDictionaryID = mObjectsContext->GetInDirectObjectsRegistry().AllocateNewObjectID();
@@ -943,7 +943,7 @@ PDFTiledPattern* DocumentContext::StartTiledPattern(int inPaintType,
 							 inBoundingBox,
 							 inXStep,
 							 inYStep,
-							 objectID, 
+							 objectID,
 							 inMatrix);
 
 }
@@ -997,8 +997,8 @@ PDFFormXObject* DocumentContext::StartFormXObject(const PDFRectangle& inBounding
 	  mObjectsContext->EndDictionary(groupContext);
         }
 
-		// Resource dict 
-		xobjectContext->WriteKey(scResources);	
+		// Resource dict
+		xobjectContext->WriteKey(scResources);
 		// put a resources dictionary place holder
 		ObjectIDType formXObjectResourcesDictionaryID = mObjectsContext->GetInDirectObjectsRegistry().AllocateNewObjectID();
 		xobjectContext->WriteNewObjectReferenceValue(formXObjectResourcesDictionaryID);
@@ -1021,7 +1021,7 @@ PDFFormXObject* DocumentContext::StartFormXObject(const PDFRectangle& inBounding
 		aFormXObject =  new PDFFormXObject(this,inFormXObjectID,mObjectsContext->StartPDFStream(xobjectContext),formXObjectResourcesDictionaryID);
 	} while(false);
 
-	return aFormXObject;	
+	return aFormXObject;
 }
 
 
@@ -1039,24 +1039,24 @@ EStatusCode DocumentContext::EndFormXObjectNoRelease(PDFFormXObject* inFormXObje
 	mObjectsContext->StartNewIndirectObject(inFormXObject->GetResourcesDictionaryObjectID());
 	WriteResourcesDictionary(inFormXObject->GetResourcesDictionary());
 	mObjectsContext->EndIndirectObject();
-	
+
     // now write writing tasks
     PDFFormXObjectToIFormEndWritingTaskListMap::iterator it= mFormEndTasks.find(inFormXObject);
-    
+
     EStatusCode status = eSuccess;
     if(it != mFormEndTasks.end())
     {
         IFormEndWritingTaskList::iterator itTasks = it->second.begin();
-        
+
         for(; itTasks != it->second.end() && eSuccess == status; ++itTasks)
             status = (*itTasks)->Write(inFormXObject,mObjectsContext,this);
-        
+
         // one time, so delete
         for(itTasks = it->second.begin(); itTasks != it->second.end(); ++itTasks)
             delete (*itTasks);
-        mFormEndTasks.erase(it); 
+        mFormEndTasks.erase(it);
     }
-    
+
 	return status;
 }
 
@@ -1092,7 +1092,7 @@ EStatusCode DocumentContext::EndTiledPattern(PDFTiledPattern* inTiledPattern)
 EStatusCode DocumentContext::EndTiledPatternAndRelease(PDFTiledPattern* inTiledPattern)
 {
 	EStatusCode status = EndTiledPattern(inTiledPattern);
-	delete inTiledPattern; 
+	delete inTiledPattern;
 
 	return status;
 
@@ -1108,7 +1108,7 @@ EStatusCode DocumentContext::EndFormXObjectAndRelease(PDFFormXObject* inFormXObj
 {
 	EStatusCode status = EndFormXObjectNoRelease(inFormXObject);
 	delete inFormXObject; // will also delete the stream becuase the form XObject owns it
-	
+
 	return status;
 }
 
@@ -1136,10 +1136,10 @@ EStatusCode DocumentContext::WriteResourcesDictionary(ResourcesDictionary& inRes
         {
             resourcesContext->WriteKey(scProcesets);
             mObjectsContext->StartArray();
-            do 
+            do
             {
                 mObjectsContext->WriteName(itProcesets.GetItem());
-            } 
+            }
             while (itProcesets.MoveNext());
             mObjectsContext->EndArray();
             mObjectsContext->EndLine();
@@ -1162,7 +1162,7 @@ EStatusCode DocumentContext::WriteResourcesDictionary(ResourcesDictionary& inRes
 
 		// Color space
         status = WriteResourceDictionary(&inResourcesDictionary,resourcesContext,scColorSpaces,inResourcesDictionary.GetColorSpacesIterator());
-	
+
 		// Patterns
         status = WriteResourceDictionary(&inResourcesDictionary,resourcesContext,scPatterns,inResourcesDictionary.GetPatternsIterator());
         if(status!=eSuccess)
@@ -1189,7 +1189,7 @@ EStatusCode DocumentContext::WriteResourcesDictionary(ResourcesDictionary& inRes
 			}
 		}
 
-		mObjectsContext->EndDictionary(resourcesContext); 
+		mObjectsContext->EndDictionary(resourcesContext);
 	}while(false);
 
 	return status;
@@ -1201,16 +1201,16 @@ EStatusCode DocumentContext::WriteResourceDictionary(ResourcesDictionary* inReso
 											MapIterator<ObjectIDTypeToStringMap> inMapping)
 {
     EStatusCode status = eSuccess;
-    
-    ResourcesDictionaryAndStringToIResourceWritingTaskListMap::iterator itWriterTasks = 
+
+    ResourcesDictionaryAndStringToIResourceWritingTaskListMap::iterator itWriterTasks =
         mResourcesTasks.find(ResourcesDictionaryAndString(inResourcesDictionary,inResourceDictionaryLabel));
-    
+
     if(inMapping.MoveNext() || itWriterTasks != mResourcesTasks.end())
     {
         do {
             inResourcesCategoryDictionary->WriteKey(inResourceDictionaryLabel);
             DictionaryContext* resourceContext = mObjectsContext->StartDictionary();
-            
+
             if(!inMapping.IsFinished())
             {
                 do
@@ -1220,14 +1220,14 @@ EStatusCode DocumentContext::WriteResourceDictionary(ResourcesDictionary* inReso
                 }
                 while(inMapping.MoveNext());
             }
-            
+
             if(itWriterTasks != mResourcesTasks.end())
             {
                 IResourceWritingTaskList::iterator itTasks = itWriterTasks->second.begin();
-                
+
                 for(; itTasks != itWriterTasks->second.end() && eSuccess == status; ++itTasks)
                     status = (*itTasks)->Write(inResourcesCategoryDictionary,mObjectsContext,this);
-                
+
                 // Discard the tasks for this category
                 for(itTasks = itWriterTasks->second.begin(); itTasks != itWriterTasks->second.end(); ++itTasks)
                     delete *itTasks;
@@ -1235,7 +1235,7 @@ EStatusCode DocumentContext::WriteResourceDictionary(ResourcesDictionary* inReso
                 if(status != eSuccess)
                     break;
             }
-            
+
             IDocumentContextExtenderSet::iterator it = mExtenders.begin();
             EStatusCode status = PDFHummus::eSuccess;
             for(; it != mExtenders.end() && eSuccess == status; ++it)
@@ -1247,14 +1247,14 @@ EStatusCode DocumentContext::WriteResourceDictionary(ResourcesDictionary* inReso
                     break;
                 }
             }
-            
+
             mObjectsContext->EndDictionary(resourceContext);
-            
-        } 
+
+        }
         while (false);
 
     }
-    
+
     return status;
 }
 
@@ -1262,7 +1262,7 @@ EStatusCode DocumentContext::WriteResourceDictionary(ResourcesDictionary* inReso
 
 bool DocumentContext::IsIdentityMatrix(const double* inMatrix)
 {
-	return 
+	return
 		inMatrix[0] == 1 &&
 		inMatrix[1] == 0 &&
 		inMatrix[2] == 0 &&
@@ -1303,7 +1303,7 @@ TIFFImageHandler& DocumentContext::GetTIFFImageHandler()
 PDFFormXObject* DocumentContext::CreateFormXObjectFromTIFFFile(	const std::string& inTIFFFilePath,
 																const TIFFUsageParameters& inTIFFUsageParameters)
 {
-	
+
 	return mTIFFImageHandler.CreateFormXObjectFromTIFFFile(inTIFFFilePath,inTIFFUsageParameters);
 }
 
@@ -1366,7 +1366,7 @@ EStatusCodeAndObjectIDTypeList DocumentContext::CreateFormXObjectsFromPDF(const 
 																			const ObjectIDTypeList& inCopyAdditionalObjects,
 																			const ObjectIDTypeList& inPredefinedFormIDs)
 {
-	return mPDFDocumentHandler.CreateFormXObjectsFromPDF(inPDFFilePath,inParsingOptions,inPageRange,inPageBoxToUseAsFormBox,inTransformationMatrix,inCopyAdditionalObjects,inPredefinedFormIDs);	
+	return mPDFDocumentHandler.CreateFormXObjectsFromPDF(inPDFFilePath,inParsingOptions,inPageRange,inPageBoxToUseAsFormBox,inTransformationMatrix,inCopyAdditionalObjects,inPredefinedFormIDs);
 
 }
 
@@ -1378,7 +1378,7 @@ EStatusCodeAndObjectIDTypeList DocumentContext::CreateFormXObjectsFromPDF(const 
 																			const ObjectIDTypeList& inCopyAdditionalObjects,
 																			const ObjectIDTypeList& inPredefinedFormIDs)
 {
-	return mPDFDocumentHandler.CreateFormXObjectsFromPDF(inPDFFilePath,inParsingOptions,inPageRange,inCropBox,inTransformationMatrix,inCopyAdditionalObjects, inPredefinedFormIDs);	
+	return mPDFDocumentHandler.CreateFormXObjectsFromPDF(inPDFFilePath,inParsingOptions,inPageRange,inCropBox,inTransformationMatrix,inCopyAdditionalObjects, inPredefinedFormIDs);
 
 }
 EStatusCodeAndObjectIDTypeList DocumentContext::AppendPDFPagesFromPDF(const std::string& inPDFFilePath,
@@ -1386,7 +1386,7 @@ EStatusCodeAndObjectIDTypeList DocumentContext::AppendPDFPagesFromPDF(const std:
 																	  const PDFPageRange& inPageRange,
 																	  const ObjectIDTypeList& inCopyAdditionalObjects)
 {
-	return mPDFDocumentHandler.AppendPDFPagesFromPDF(inPDFFilePath,inParsingOptions,inPageRange,inCopyAdditionalObjects);	
+	return mPDFDocumentHandler.AppendPDFPagesFromPDF(inPDFFilePath,inParsingOptions,inPageRange,inCopyAdditionalObjects);
 }
 
 EStatusCode DocumentContext::WriteState(ObjectsContext* inStateWriter,ObjectIDType inObjectID)
@@ -1422,7 +1422,7 @@ EStatusCode DocumentContext::WriteState(ObjectsContext* inStateWriter,ObjectIDTy
 
         documentDictionary->WriteKey("mModifiedDocumentIDExists");
         documentDictionary->WriteBooleanValue(mModifiedDocumentIDExists);
-        
+
         if(mModifiedDocumentIDExists)
         {
             documentDictionary->WriteKey("mModifiedDocumentID");
@@ -1440,7 +1440,7 @@ EStatusCode DocumentContext::WriteState(ObjectsContext* inStateWriter,ObjectIDTy
 
 		WriteTrailerState(inStateWriter,trailerInformationID);
 		WriteCatalogInformationState(inStateWriter,catalogInformationID);
-		
+
 		status = mUsedFontsRepository.WriteState(inStateWriter,usedFontsRepositoryID);
 		if(status != PDFHummus::eSuccess)
 			break;
@@ -1457,13 +1457,13 @@ void DocumentContext::WriteReferenceState(ObjectsContext* inStateWriter,
                                           const ObjectReference& inReference)
 {
     DictionaryContext* referenceContext = inStateWriter->StartDictionary();
-    
+
     referenceContext->WriteKey("ObjectID");
     referenceContext->WriteIntegerValue(inReference.ObjectID);
-    
+
     referenceContext->WriteKey("GenerationNumber");
     referenceContext->WriteIntegerValue(inReference.GenerationNumber);
-    
+
     inStateWriter->EndDictionary(referenceContext);
 }
 
@@ -1613,7 +1613,7 @@ void DocumentContext::WriteCatalogInformationState(ObjectsContext* inStateWriter
 
 	inStateWriter->EndDictionary(catalogInformation);
 	inStateWriter->EndIndirectObject();
-	
+
 }
 
 void DocumentContext::WritePageTreeState(ObjectsContext* inStateWriter,ObjectIDType inObjectID,PageTree* inPageTree)
@@ -1622,7 +1622,7 @@ void DocumentContext::WritePageTreeState(ObjectsContext* inStateWriter,ObjectIDT
 
 	inStateWriter->StartNewIndirectObject(inObjectID);
 	DictionaryContext* pageTreeDictionary = inStateWriter->StartDictionary();
-	
+
 	pageTreeDictionary->WriteKey("Type");
 	pageTreeDictionary->WriteNameValue("PageTree");
 
@@ -1650,7 +1650,7 @@ void DocumentContext::WritePageTreeState(ObjectsContext* inStateWriter,ObjectIDT
 			inStateWriter->WriteNewIndirectObjectReference(pageNodeObjectID);
 			kidsObjectIDs.push_back(pageNodeObjectID);
 		}
-		inStateWriter->EndArray(eTokenSeparatorEndLine);		
+		inStateWriter->EndArray(eTokenSeparatorEndLine);
 	}
 
 	inStateWriter->EndDictionary(pageTreeDictionary);
@@ -1675,14 +1675,14 @@ EStatusCode DocumentContext::ReadState(PDFParser* inStateReader,ObjectIDType inO
 	PDFObjectCastPtr<PDFDictionary> documentState(inStateReader->ParseNewObject(inObjectID));
 
     PDFObjectCastPtr<PDFBoolean> modifiedDocumentExists(documentState->QueryDirectObject("mModifiedDocumentIDExists"));
-    mModifiedDocumentIDExists = modifiedDocumentExists->GetValue();                        
-    
+    mModifiedDocumentIDExists = modifiedDocumentExists->GetValue();
+
     if(mModifiedDocumentIDExists)
     {
         PDFObjectCastPtr<PDFHexString> modifiedDocumentExists(documentState->QueryDirectObject("mModifiedDocumentID"));
         mModifiedDocumentID = modifiedDocumentExists->GetValue();
-    }    
-    
+    }
+
 	PDFObjectCastPtr<PDFHexString> newPDFID(documentState->QueryDirectObject("mNewPDFID"));
 
 	if (!!newPDFID)
@@ -1726,7 +1726,7 @@ ObjectReference DocumentContext::GetReferenceFromState(PDFDictionary* inDictiona
 {
     PDFObjectCastPtr<PDFInteger> objectID(inDictionary->QueryDirectObject("ObjectID"));
     PDFObjectCastPtr<PDFInteger> generationNumber(inDictionary->QueryDirectObject("GenerationNumber"));
-    
+
     return ObjectReference((ObjectIDType)(objectID->GetValue()),(unsigned long)generationNumber->GetValue());
 }
 
@@ -1824,7 +1824,7 @@ void DocumentContext::ReadCatalogInformationState(PDFParser* inStateReader,PDFDi
 	mCurrentPageTreeIDInState = currentPageTreeState->mObjectID;
 
 	PDFObjectCastPtr<PDFDictionary> pageTreeState(inStateReader->ParseNewObject(pageTreeRootState->mObjectID));
-	
+
 	PDFObjectCastPtr<PDFInteger> pageTreeIDState(pageTreeState->QueryDirectObject("mPageTreeID"));
 	PageTree* rootNode = new PageTree((ObjectIDType)pageTreeIDState->GetValue());
 
@@ -1838,12 +1838,12 @@ void DocumentContext::ReadPageTreeState(PDFParser* inStateReader,PDFDictionary* 
 {
 	PDFObjectCastPtr<PDFBoolean> isLeafParentState(inPageTreeState->QueryDirectObject("mIsLeafParent"));
 	bool isLeafParent = isLeafParentState->GetValue();
-		
+
 	if(isLeafParent)
 	{
 		PDFObjectCastPtr<PDFArray> kidsIDsState(inPageTreeState->QueryDirectObject("mKidsIDs"));
 		PDFObjectCastPtr<PDFInteger> kidID;
-		
+
 		SingleValueContainerIterator<PDFObjectVector> it = kidsIDsState->GetIterator();
 		while(it.MoveNext())
 		{
@@ -1962,7 +1962,7 @@ EStatusCodeAndObjectIDType DocumentContext::WriteAnnotationAndLinkForURL(const s
 		// URI
 		actionContext->WriteKey(scURI);
 		actionContext->WriteLiteralStringValue(encodedResult.second);
-		
+
 		mObjectsContext->EndDictionary(actionContext);
 
 		mObjectsContext->EndDictionary(linkAnnotationContext);
@@ -2088,37 +2088,37 @@ void DocumentContext::Cleanup()
 		(*it)->ReleaseDocumentContextReference();
 	mCopyingContexts.clear();
     mModifiedDocumentIDExists = false;
-    
+
     ResourcesDictionaryAndStringToIResourceWritingTaskListMap::iterator itCategories = mResourcesTasks.begin();
-    
+
     for(; itCategories != mResourcesTasks.end(); ++itCategories)
     {
         IResourceWritingTaskList::iterator itWritingTasks = itCategories->second.begin();
         for(; itWritingTasks != itCategories->second.end(); ++itWritingTasks)
             delete *itWritingTasks;
     }
-    
+
     mResourcesTasks.clear();
-    
+
     PDFFormXObjectToIFormEndWritingTaskListMap::iterator itFormEnd = mFormEndTasks.begin();
-    
+
     for(; itFormEnd != mFormEndTasks.end();++itFormEnd)
     {
         IFormEndWritingTaskList::iterator itEndWritingTasks = itFormEnd->second.begin();
         for(; itEndWritingTasks != itFormEnd->second.end(); ++itEndWritingTasks)
             delete *itEndWritingTasks;
-        
+
     }
     mFormEndTasks.clear();
-    
+
     PDFPageToIPageEndWritingTaskListMap::iterator itPageEnd = mPageEndTasks.begin();
-    
+
     for(; itPageEnd != mPageEndTasks.end();++itPageEnd)
     {
         IPageEndWritingTaskList::iterator itPageEndWritingTasks = itPageEnd->second.begin();
         for(; itPageEndWritingTasks != itPageEnd->second.end(); ++itPageEndWritingTasks)
             delete *itPageEndWritingTasks;
-        
+
     }
     mPageEndTasks.clear();
 
@@ -2154,21 +2154,21 @@ void DocumentContext::UnRegisterCopyingContext(PDFDocumentCopyingContext* inCopy
 EStatusCode DocumentContext::SetupModifiedFile(PDFParser* inModifiedFileParser)
 {
     // setup trailer and save original document ID
-    
+
     if(!inModifiedFileParser->GetTrailer())
         return eFailure;
-    
+
     PDFObjectCastPtr<PDFIndirectObjectReference> rootReference = inModifiedFileParser->GetTrailer()->QueryDirectObject("Root");
     if(!rootReference)
         return eFailure;
-    
+
     // set catalog reference and previous reference table position
     mTrailerInformation.SetRoot(rootReference->mObjectID);
     mTrailerInformation.SetPrev(inModifiedFileParser->GetXrefPosition());
-    
+
     // setup modified date to current time
     mTrailerInformation.GetInfo().ModDate.SetToCurrentTime();
-    
+
     // try to get document ID. in any case use whatever was the original
     mModifiedDocumentIDExists = true;
     mModifiedDocumentID = "";
@@ -2179,7 +2179,7 @@ EStatusCode DocumentContext::SetupModifiedFile(PDFParser* inModifiedFileParser)
         if(firstID.GetPtr())
             mModifiedDocumentID = firstID->GetValue();
     }
-    
+
     return eSuccess;
 }
 
@@ -2195,7 +2195,7 @@ public:
 		mPDFVersion = inPDFVersion;
 	}
     virtual ~ModifiedDocCatalogWriterExtension(){}
-    
+
     // IDocumentContextExtender implementation
 	virtual PDFHummus::EStatusCode OnCatalogWrite(
             CatalogInformation* inCatalogInformation,
@@ -2232,10 +2232,10 @@ public:
 			}
 		}
 
-        
+
         return eSuccess;
-    }    
-    
+    }
+
 private:
 	PDFDocumentCopyingContext* mModifiedDocumentCopyingContext;
 	bool mRequiresVersionUpdate;
@@ -2246,30 +2246,30 @@ EStatusCode	DocumentContext::FinalizeModifiedPDF(PDFParser* inModifiedFileParser
 {
 	EStatusCode status;
 	LongFilePositionType xrefTablePosition;
-    
+
 	do
 	{
 		status = WriteUsedFontsDefinitions();
 		if(status != eSuccess)
 			break;
-        
+
         // Page tree writing
         // k. page tree needs to be a combination of what pages are coming from the original document
         // and those from the new one. The decision whether a new page tree need to be written is simple -
         // if no pages were added...no new page tree...if yes...then we need a new page tree which will combine
         // the new pages and the old pages
-        
+
         ObjectReference originalDocumentPageTreeRoot = GetOriginalDocumentPageTreeRoot(inModifiedFileParser);
         bool hasNewPageTreeRoot;
         ObjectReference finalPageRoot;
-        
+
         if(DocumentHasNewPages())
         {
             if(originalDocumentPageTreeRoot.ObjectID != 0)
             {
                 finalPageRoot.ObjectID = WriteCombinedPageTree(inModifiedFileParser);
                 finalPageRoot.GenerationNumber = 0;
-                
+
                 // check for error - may fail to write combined page tree if document is protected!
                 if(finalPageRoot.ObjectID == 0)
                 {
@@ -2293,9 +2293,9 @@ EStatusCode	DocumentContext::FinalizeModifiedPDF(PDFParser* inModifiedFileParser
             finalPageRoot = originalDocumentPageTreeRoot;
         }
         // marking if has new page root, cause this effects the decision to have a new catalog
-        
+
         bool requiresVersionUpdate = IsRequiredVersionHigherThanPDFVersion(inModifiedFileParser,inModifiedPDFVersion);
-        
+
         if(hasNewPageTreeRoot || requiresVersionUpdate || DoExtendersRequireCatalogUpdate(inModifiedFileParser))
         {
 			// use an extender to copy original catalog elements and update version if required
@@ -2306,13 +2306,13 @@ EStatusCode	DocumentContext::FinalizeModifiedPDF(PDFParser* inModifiedFileParser
             if(status != eSuccess)
                 break;
         }
-                
+
  		// write the info dictionary of the trailer, if has any valid entries
 		WriteInfoDictionary();
 
 		// write encryption dictionary, if encrypting
 		CopyEncryptionDictionary(inModifiedFileParser);
-        
+
         if(RequiresXrefStream(inModifiedFileParser))
         {
             status = WriteXrefStream(xrefTablePosition);
@@ -2322,25 +2322,25 @@ EStatusCode	DocumentContext::FinalizeModifiedPDF(PDFParser* inModifiedFileParser
             status = mObjectsContext->WriteXrefTable(xrefTablePosition);
             if(status != eSuccess)
                 break;
-            
+
             status = WriteTrailerDictionary();
             if(status != eSuccess)
                 break;
-            
+
         }
-        
+
 		WriteXrefReference(xrefTablePosition);
 		WriteFinalEOF();
 	} while(false);
-    
+
 	return status;
 }
 
 ObjectReference DocumentContext::GetOriginalDocumentPageTreeRoot(PDFParser* inModifiedFileParser)
 {
 	ObjectReference rootObject;
-    
-	
+
+
 	do
 	{
 		// get catalogue, verify indirect reference
@@ -2350,14 +2350,14 @@ ObjectReference DocumentContext::GetOriginalDocumentPageTreeRoot(PDFParser* inMo
 			TRACE_LOG("DocumentContext::GetOriginalDocumentPageTreeRoot, failed to read catalog reference in trailer");
 			break;
 		}
-        
+
 		PDFObjectCastPtr<PDFDictionary> catalog(inModifiedFileParser->ParseNewObject(catalogReference->mObjectID));
 		if(!catalog)
 		{
 			TRACE_LOG("DocumentContext::GetOriginalDocumentPageTreeRoot, failed to read catalog");
 			break;
 		}
-        
+
 		// get pages, verify indirect reference
 		PDFObjectCastPtr<PDFIndirectObjectReference> pagesReference(catalog->QueryDirectObject("Pages"));
 		if(!pagesReference)
@@ -2365,7 +2365,7 @@ ObjectReference DocumentContext::GetOriginalDocumentPageTreeRoot(PDFParser* inMo
 			TRACE_LOG("PDFParser::GetOriginalDocumentPageTreeRoot, failed to read pages reference in catalog");
 			break;
 		}
-        
+
 		// check if the pages tree is not deleted. this should allow users
 		// to override the page tree
 		GetObjectWriteInformationResult objectRegistryData = mObjectsContext->GetInDirectObjectsRegistry().GetObjectWriteInformation(pagesReference->mObjectID);
@@ -2376,32 +2376,32 @@ ObjectReference DocumentContext::GetOriginalDocumentPageTreeRoot(PDFParser* inMo
 		}
 
 	}while(false);
-    
-	return rootObject;    
-    
+
+	return rootObject;
+
 }
 
 bool DocumentContext::DocumentHasNewPages()
 {
     // the best way to check if there are new pages created is to check if there's at least one leaf
-    
+
     if(!mCatalogInformation.GetCurrentPageTreeNode())
         return false;
-    
+
     // note that page tree root surely exist, so no worries about creating a new one
     PageTree* pageTreeRoot = mCatalogInformation.GetPageTreeRoot(mObjectsContext->GetInDirectObjectsRegistry());
-    
+
     bool hasLeafs = false;
-    
+
     while(hasLeafs == false)
     {
         hasLeafs = pageTreeRoot->IsLeafParent();
         if(pageTreeRoot->GetNodesCount() == 0)
             break;
-        else 
+        else
             pageTreeRoot = pageTreeRoot->GetPageTreeChild(0);
     }
- 
+
     return hasLeafs;
 }
 
@@ -2414,47 +2414,47 @@ ObjectIDType DocumentContext::WriteCombinedPageTree(PDFParser* inModifiedFilePar
     // of the old tree, but with the parent object pointing to the new root object.
     // now write the new root object with allocated ID and the old and new pages trees roots as direct children.
     // happy.
-    
-    
+
+
     // allocate new root object
     ObjectIDType newPageRootTreeID = mObjectsContext->GetInDirectObjectsRegistry().AllocateNewObjectID();
-    
+
     PageTree* root = new PageTree(newPageRootTreeID);
-	
+
     // write new pages tree
     PageTree* newPagesTree = mCatalogInformation.GetPageTreeRoot(mObjectsContext->GetInDirectObjectsRegistry());
     newPagesTree->SetParent(root);
  	long long newPagesCount = WritePageTree(newPagesTree);
     newPagesTree->SetParent(NULL);
     delete root;
-    
+
     // write modified old pages root
     ObjectReference originalTreeRoot = GetOriginalDocumentPageTreeRoot(inModifiedFileParser);
-    
+
     PDFObjectCastPtr<PDFDictionary> originalTreeRootObject = inModifiedFileParser->ParseNewObject(originalTreeRoot.ObjectID);
-  
+
     mObjectsContext->StartModifiedIndirectObject(originalTreeRoot.ObjectID);
-    
+
     DictionaryContext* pagesTreeContext = mObjectsContext->StartDictionary();
- 
+
     PDFObjectCastPtr<PDFInteger> kidsCount = originalTreeRootObject->QueryDirectObject(scCount);
     long long originalPageTreeKidsCount = kidsCount.GetPtr() ? kidsCount->GetValue() : 0;
-    
+
     // copy all but parent key. then add parent as the new root object
-    
+
     MapIterator<PDFNameToPDFObjectMap>  pageTreeIt = originalTreeRootObject->GetIterator();
     PDFDocumentCopyingContext aCopyingContext;
-    
+
     EStatusCode status = aCopyingContext.Start(inModifiedFileParser,this,mObjectsContext);
-    
+
     do {
-        
+
         if(status != eSuccess)
         {
             TRACE_LOG("DocumentContext::WriteCombinedPageTree, Unable to copy original page tree. this probably means that the original file is protected - and is therefore unsupported for such activity as adding pages");
             break;
         }
-        
+
         while(pageTreeIt.MoveNext())
         {
             if(pageTreeIt.GetKey()->GetValue() != "Parent")
@@ -2462,54 +2462,54 @@ ObjectIDType DocumentContext::WriteCombinedPageTree(PDFParser* inModifiedFilePar
                 pagesTreeContext->WriteKey(pageTreeIt.GetKey()->GetValue());
                 aCopyingContext.CopyDirectObjectAsIs(pageTreeIt.GetValue());
             }
-            
+
         }
-        
+
         aCopyingContext.End();
-    
+
         // parent
         pagesTreeContext->WriteKey(scParent);
         pagesTreeContext->WriteNewObjectReferenceValue(newPageRootTreeID);
-        
+
         mObjectsContext->EndDictionary(pagesTreeContext);
         mObjectsContext->EndIndirectObject();
-        
+
         // now write the root page tree. 2 kids, the original pages, and new pages
         mObjectsContext->StartNewIndirectObject(newPageRootTreeID);
-        
+
         pagesTreeContext = mObjectsContext->StartDictionary();
-        
+
         // type
         pagesTreeContext->WriteKey(scType);
         pagesTreeContext->WriteNameValue(scPages);
-        
+
         // count
-        pagesTreeContext->WriteKey(scCount);    
+        pagesTreeContext->WriteKey(scCount);
         pagesTreeContext->WriteIntegerValue(originalPageTreeKidsCount + newPagesCount);
-        
+
         // kids
         pagesTreeContext->WriteKey(scKids);
         mObjectsContext->StartArray();
-        
+
         mObjectsContext->WriteIndirectObjectReference(originalTreeRoot);
         mObjectsContext->WriteNewIndirectObjectReference(newPagesTree->GetID());
-        
+
         mObjectsContext->EndArray();
         mObjectsContext->EndLine();
 
         mObjectsContext->EndDictionary(pagesTreeContext);
         mObjectsContext->EndIndirectObject();
-    
+
     } while (false);
-   
-    
+
+
 
     if(status == eSuccess)
         return newPageRootTreeID;
     else
         return 0;
 }
-           
+
 bool DocumentContext::IsRequiredVersionHigherThanPDFVersion(PDFParser* inModifiedFileParser,EPDFVersion inModifiedPDFVersion)
 {
     return (EPDFVersion)((size_t)(inModifiedFileParser->GetPDFLevel() * 10)) < inModifiedPDFVersion;
@@ -2518,15 +2518,15 @@ bool DocumentContext::IsRequiredVersionHigherThanPDFVersion(PDFParser* inModifie
 bool DocumentContext::DoExtendersRequireCatalogUpdate(PDFParser* inModifiedFileParser)
 {
     bool isUpdateRequired = false;
-    
+
  	IDocumentContextExtenderSet::iterator it = mExtenders.begin();
 	for(; it != mExtenders.end() && !isUpdateRequired; ++it)
 		isUpdateRequired = (*it)->IsCatalogUpdateRequiredForModifiedFile(inModifiedFileParser);
-    
+
     return isUpdateRequired;
 }
 
-void DocumentContext::CopyEncryptionDictionary(PDFParser* inModifiedFileParser) 
+void DocumentContext::CopyEncryptionDictionary(PDFParser* inModifiedFileParser)
 {
 	// Reuse original encryption dict for new modified trailer. for sake of simplicity (with trailer using ref for encrypt), make it indirect if not already
 	RefCountPtr<PDFObject> encrypt(inModifiedFileParser->GetTrailer()->QueryDirectObject("Encrypt"));
@@ -2559,38 +2559,38 @@ bool DocumentContext::RequiresXrefStream(PDFParser* inModifiedFileParser)
     // modification requires xref stream if the original document uses one...so just ask trailer
     if(!inModifiedFileParser->GetTrailer())
         return false;
-    
+
     PDFObjectCastPtr<PDFName> typeObject = inModifiedFileParser->GetTrailer()->QueryDirectObject("Type");
-    
+
     if(!typeObject)
         return false;
-    
+
     return typeObject->GetValue() == "XRef";
-    
-    
+
+
 }
 
 EStatusCode DocumentContext::WriteXrefStream(LongFilePositionType& outXrefPosition)
 {
     EStatusCode status = eSuccess;
-    
-    do 
+
+    do
     {
 		mEncryptionHelper.PauseEncryption(); // don't encrypt while writing xref stream
         // get the position by accessing the free context of the underlying objects stream
- 
+
         // an Xref stream is a beast that is both trailer and the xref
         // start the xref with a dictionary detailing the trailer information, then move to the
         // xref table aspects, with the lower level objects context.
-        
+
         outXrefPosition = mObjectsContext->GetCurrentPosition();
         mObjectsContext->StartNewIndirectObject();
- 
+
         DictionaryContext* xrefDictionary = mObjectsContext->StartDictionary();
-        
+
         xrefDictionary->WriteKey("Type");
         xrefDictionary->WriteNameValue("XRef");
-        
+
         status = WriteTrailerDictionaryValues(xrefDictionary);
         if(status != eSuccess)
             break;
@@ -2599,17 +2599,17 @@ EStatusCode DocumentContext::WriteXrefStream(LongFilePositionType& outXrefPositi
         status = mObjectsContext->WriteXrefStream(xrefDictionary);
 
 		mEncryptionHelper.ReleaseEncryption();
-        
-    } 
+
+    }
     while (false);
-    
+
     return status;
 }
 
 PDFDocumentCopyingContext* DocumentContext::CreatePDFCopyingContext(PDFParser* inPDFParser)
 {
 	PDFDocumentCopyingContext* context = new PDFDocumentCopyingContext();
-    
+
 	if(context->Start(inPDFParser,this,mObjectsContext) != PDFHummus::eSuccess)
 	{
 		delete context;
@@ -2640,10 +2640,10 @@ std::string DocumentContext::AddExtendedResourceMapping(ResourcesDictionary* inR
 {
     // do two things. first is to include this writing task as part of the tasks to write
     // second is to allocate a name for this resource from the resource category in the relevant dictionary
-    
+
     ResourcesDictionaryAndStringToIResourceWritingTaskListMap::iterator it =
     mResourcesTasks.find(ResourcesDictionaryAndString(inResourceDictionary,inResourceCategoryName));
-    
+
     if(it == mResourcesTasks.end())
     {
         it =mResourcesTasks.insert(
@@ -2651,11 +2651,11 @@ std::string DocumentContext::AddExtendedResourceMapping(ResourcesDictionary* inR
                                                                                                              ResourcesDictionaryAndString(inResourceDictionary,inResourceCategoryName),
                                                                                                              IResourceWritingTaskList())).first;
     }
-    
+
     it->second.push_back(inWritingTask);
-    
+
     std::string newResourceName;
-    
+
     if(inResourceCategoryName == scXObjects)
         newResourceName = inResourceDictionary->AddXObjectMapping(0);
     else if(inResourceCategoryName == scExtGStates)
@@ -2685,27 +2685,27 @@ std::string DocumentContext::AddExtendedResourceMapping(PDFFormXObject* inFormXO
 
 void DocumentContext::RegisterFormEndWritingTask(PDFFormXObject* inFormXObject,IFormEndWritingTask* inWritingTask)
 {
-    PDFFormXObjectToIFormEndWritingTaskListMap::iterator it = 
+    PDFFormXObjectToIFormEndWritingTaskListMap::iterator it =
     mFormEndTasks.find(inFormXObject);
-    
+
     if(it == mFormEndTasks.end())
     {
         it =mFormEndTasks.insert(PDFFormXObjectToIFormEndWritingTaskListMap::value_type(inFormXObject,IFormEndWritingTaskList())).first;
     }
-    
-    it->second.push_back(inWritingTask);    
+
+    it->second.push_back(inWritingTask);
 }
 
 void DocumentContext::RegisterPageEndWritingTask(PDFPage* inPage,IPageEndWritingTask* inWritingTask)
 {
     PDFPageToIPageEndWritingTaskListMap::iterator it =
     mPageEndTasks.find(inPage);
-    
+
     if(it == mPageEndTasks.end())
     {
         it =mPageEndTasks.insert(PDFPageToIPageEndWritingTaskListMap::value_type(inPage,IPageEndWritingTaskList())).first;
     }
-    
+
     it->second.push_back(inWritingTask);
 }
 
@@ -2723,6 +2723,83 @@ void DocumentContext::RegisterTiledPatternEndWritingTask(PDFTiledPattern* inPatt
 }
 
 DoubleAndDoublePair DocumentContext::GetImageDimensions(
+	IByteReaderWithPosition* inImageStream,
+	unsigned long inImageIndex,
+	const PDFParsingOptions& inOptions)
+{
+  double imageWidth = 0.0;
+	double imageHeight = 0.0;
+
+  LongFilePositionType recordedPosition = inImageStream->GetCurrentPosition();
+
+	EHummusImageType imageType = GetImageType(inImageStream,inImageIndex);
+
+  switch(imageType)
+  {
+    case ePDF:
+    {
+      // get the dimensions via the PDF parser. will use the media rectangle to draw image
+      PDFParser pdfParser;
+
+      if(pdfParser.StartPDFParsing(inImageStream, inOptions) != eSuccess)
+        break;
+
+      PDFPageInput helper(&pdfParser,pdfParser.ParsePage(inImageIndex));
+
+      imageWidth = helper.GetMediaBox().UpperRightX - helper.GetMediaBox().LowerLeftX;
+      imageHeight = helper.GetMediaBox().UpperRightY - helper.GetMediaBox().LowerLeftY;
+
+      break;
+    }
+    case eJPG:
+    {
+      BoolAndJPEGImageInformation jpgImageInformation = GetJPEGImageHandler().RetrieveImageInformation(inImageStream);
+      if(!jpgImageInformation.first)
+        break;
+
+      DoubleAndDoublePair dimensions = GetJPEGImageHandler().GetImageDimensions(jpgImageInformation.second);
+
+      imageWidth = dimensions.first;
+      imageHeight = dimensions.second;
+      break;
+    }
+#ifndef PDFHUMMUS_NO_TIFF
+    case eTIFF:
+    {
+      TIFFImageHandler hummusTiffHandler;
+
+      DoubleAndDoublePair dimensions = hummusTiffHandler.ReadImageDimensions(inImageStream,inImageIndex);
+
+      imageWidth = dimensions.first;
+      imageHeight = dimensions.second;
+      break;
+    }
+#endif
+#ifndef PDFHUMMUS_NO_PNG
+    case ePNG:
+    {
+      PNGImageHandler hummusPngHandler;
+
+      DoubleAndDoublePair dimensions = hummusPngHandler.ReadImageDimensions(inImageStream);
+
+      imageWidth = dimensions.first;
+      imageHeight = dimensions.second;
+      break;
+    }
+#endif
+    default:
+    {
+      // just avoding uninteresting compiler warnings. meaning...if you can't get the image type or unsupported, do nothing
+    }
+  }
+
+  // restore stream position to initial state
+  inImageStream->SetPosition(recordedPosition);
+
+  return DoubleAndDoublePair(imageWidth,imageHeight);
+}
+
+DoubleAndDoublePair DocumentContext::GetImageDimensions(
 	const std::string& inImageFile,
 	unsigned long inImageIndex,
 	const PDFParsingOptions& inOptions)
@@ -2734,27 +2811,27 @@ DoubleAndDoublePair DocumentContext::GetImageDimensions(
 
 		double imageWidth = 0.0;
 		double imageHeight = 0.0;
-    
+
 		EHummusImageType imageType = GetImageType(inImageFile,inImageIndex);
-        
+
 		switch(imageType)
 		{
 			case ePDF:
 			{
 				// get the dimensions via the PDF parser. will use the media rectangle to draw image
 				PDFParser pdfParser;
-                
+
 				InputFile file;
 				if(file.OpenFile(inImageFile) != eSuccess)
 					break;
 				if(pdfParser.StartPDFParsing(file.GetInputStream(), inOptions) != eSuccess)
 					break;
-                
+
 				PDFPageInput helper(&pdfParser,pdfParser.ParsePage(inImageIndex));
-                
+
 				imageWidth = helper.GetMediaBox().UpperRightX - helper.GetMediaBox().LowerLeftX;
 				imageHeight = helper.GetMediaBox().UpperRightY - helper.GetMediaBox().LowerLeftY;
-                
+
 				break;
 			}
 			case eJPG:
@@ -2762,9 +2839,9 @@ DoubleAndDoublePair DocumentContext::GetImageDimensions(
 				BoolAndJPEGImageInformation jpgImageInformation = GetJPEGImageHandler().RetrieveImageInformation(inImageFile);
 				if(!jpgImageInformation.first)
 					break;
-                
+
 				DoubleAndDoublePair dimensions = GetJPEGImageHandler().GetImageDimensions(jpgImageInformation.second);
-                
+
 				imageWidth = dimensions.first;
 				imageHeight = dimensions.second;
 				break;
@@ -2773,13 +2850,13 @@ DoubleAndDoublePair DocumentContext::GetImageDimensions(
 			case eTIFF:
 			{
 				TIFFImageHandler hummusTiffHandler;
-                
+
 				InputFile file;
 				if(file.OpenFile(inImageFile) != eSuccess)
 				{
 					break;
 				}
-                
+
 				DoubleAndDoublePair dimensions = hummusTiffHandler.ReadImageDimensions(file.GetInputStream(),inImageIndex);
 
 				imageWidth = dimensions.first;
@@ -2814,7 +2891,7 @@ DoubleAndDoublePair DocumentContext::GetImageDimensions(
 		imageInformation.imageHeight = imageHeight;
 		imageInformation.imageWidth = imageWidth;
 	}
-    
+
     return DoubleAndDoublePair(imageInformation.imageWidth,imageInformation.imageHeight);
 }
 
@@ -2826,6 +2903,46 @@ static const Byte scMagicTIFFLittleEndianTiff[] = {0x49,0x49,0x2A,0x00};
 static const Byte scMagicTIFFLittleEndianBigTiff[] = {0x49,0x49,0x2B,0x00};
 static const Byte scMagicPng[] = { 0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a };
 
+PDFHummus::EHummusImageType DocumentContext::GetImageType(IByteReaderWithPosition* inImageStream,unsigned long inImageIndex)
+{
+	// The types of images that are discovered here are those familiar to Hummus - JPG, TIFF and PDF
+	// PDF is recognized by starting with "%PDF"
+	// JPG will start with "0xff,0xd8"
+	// TIFF will start with "0x49,0x49" (little endian) or "0x4D,0x4D" (big endian)
+	// then either 42 or 43 (tiff or big tiff respectively) written in 2 bytes, as either big or little endian
+	// PNG will start with 89 50 4e 47 0d 0a 1a 0a
+
+	// so just read the first 8 bytes and it should be enough to recognize a known format
+
+	Byte magic[8];
+	unsigned long readLength = 8;
+	PDFHummus::EHummusImageType imageType;
+
+  LongFilePositionType recordedPosition = inImageStream->GetCurrentPosition();
+
+  inImageStream->Read(magic,readLength);
+
+	if(readLength >= 4 && memcmp(scPDFMagic,magic,4) == 0)
+		imageType =  PDFHummus::ePDF;
+	else if(readLength >= 2 && memcmp(scMagicJPG,magic,2) == 0)
+		imageType = PDFHummus::eJPG;
+	else if(readLength >= 4 && memcmp(scMagicTIFFBigEndianTiff,magic,4) == 0)
+		imageType = PDFHummus::eTIFF;
+	else if(readLength >= 4 && memcmp(scMagicTIFFBigEndianBigTiff,magic,4) == 0)
+		imageType = PDFHummus::eTIFF;
+	else if(readLength >= 4 && memcmp(scMagicTIFFLittleEndianTiff,magic,4) == 0)
+		imageType = PDFHummus::eTIFF;
+	else if(readLength >= 4 && memcmp(scMagicTIFFLittleEndianBigTiff,magic,4) == 0)
+		imageType = PDFHummus::eTIFF;
+	else if (readLength >= 8 && memcmp(scMagicPng, magic, 8) == 0)
+		imageType = PDFHummus::ePNG;
+	else
+		imageType = PDFHummus::eUndefined;
+
+  inImageStream->SetPosition(recordedPosition);
+
+  return imageType;
+}
 
 PDFHummus::EHummusImageType DocumentContext::GetImageType(const std::string& inImageFile,unsigned long inImageIndex)
 {
@@ -2841,9 +2958,9 @@ PDFHummus::EHummusImageType DocumentContext::GetImageType(const std::string& inI
 		// TIFF will start with "0x49,0x49" (little endian) or "0x4D,0x4D" (big endian)
 		// then either 42 or 43 (tiff or big tiff respectively) written in 2 bytes, as either big or little endian
 		// PNG will start with 89 50 4e 47 0d 0a 1a 0a
-        
+
 		// so just read the first 8 bytes and it should be enough to recognize a known format
-        
+
 		Byte magic[8];
 		unsigned long readLength = 8;
 		InputFile inputFile;
@@ -2851,7 +2968,7 @@ PDFHummus::EHummusImageType DocumentContext::GetImageType(const std::string& inI
 		if(inputFile.OpenFile(inImageFile) == eSuccess)
 		{
 			inputFile.GetInputStream()->Read(magic,readLength);
-        
+
 			if(readLength >= 4 && memcmp(scPDFMagic,magic,4) == 0)
 				imageType =  PDFHummus::ePDF;
 			else if(readLength >= 2 && memcmp(scMagicJPG,magic,2) == 0)
@@ -2874,7 +2991,7 @@ PDFHummus::EHummusImageType DocumentContext::GetImageType(const std::string& inI
 
 		imageInformation.imageType = imageType;
 	}
-    
+
     return imageInformation.imageType;
 }
 
@@ -2940,7 +3057,7 @@ EStatusCode DocumentContext::WriteFormForImage(
 {
     EStatusCode status = eFailure;
     EHummusImageType imageType = GetImageType(inImagePath,inImageIndex);
-        
+
     switch(imageType)
     {
         case ePDF:
@@ -2964,7 +3081,7 @@ EStatusCode DocumentContext::WriteFormForImage(
         {
             TIFFUsageParameters params;
             params.PageIndex = (unsigned int)inImageIndex;
-            
+
             PDFFormXObject* form = CreateFormXObjectFromTIFFFile(inImagePath,inObjectID,params);
             status = (form ? eSuccess:eFailure);
             delete form;
@@ -2996,12 +3113,12 @@ EStatusCode DocumentContext::WriteFormForImage(
 HummusImageInformation& DocumentContext::GetImageInformationStructFor(const std::string& inImageFile,unsigned long inImageIndex)
 {
     StringAndULongPairToHummusImageInformationMap::iterator it = mImagesInformation.find(StringAndULongPair(inImageFile,inImageIndex));
-    
+
     if(it == mImagesInformation.end())
         it = mImagesInformation.insert(
                         StringAndULongPairToHummusImageInformationMap::value_type(
                                 StringAndULongPair(inImageFile,inImageIndex),HummusImageInformation())).first;
-    
+
     return it->second;
 }
 
@@ -3010,7 +3127,7 @@ ObjectIDTypeAndBool DocumentContext::RegisterImageForDrawing(const std::string& 
 {
     HummusImageInformation& imageInformation = GetImageInformationStructFor(inImageFile,inImageIndex);
     bool firstTime;
-    
+
     if(imageInformation.writtenObjectID == 0)
     {
         imageInformation.writtenObjectID = mObjectsContext->GetInDirectObjectsRegistry().AllocateNewObjectID();
@@ -3018,6 +3135,6 @@ ObjectIDTypeAndBool DocumentContext::RegisterImageForDrawing(const std::string& 
     }
     else
         firstTime = false;
-    
+
     return ObjectIDTypeAndBool(imageInformation.writtenObjectID,firstTime);
 }

--- a/src/deps/PDFWriter/DocumentContext.h
+++ b/src/deps/PDFWriter/DocumentContext.h
@@ -16,7 +16,7 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 
-   
+
 */
 #pragma once
 
@@ -93,7 +93,7 @@ namespace PDFHummus
 	struct HummusImageInformation
 	{
 		HummusImageInformation(){writtenObjectID = 0;imageType=eUndefined;imageWidth=-1;imageHeight=-1;}
-    
+
 		ObjectIDType writtenObjectID;
 		EHummusImageType imageType;
 		double imageWidth;
@@ -145,7 +145,7 @@ namespace PDFHummus
 
 		// Determine whether this page already has a content context
 		bool HasContentContext(PDFPage* inPage);
-		
+
 		EStatusCodeAndObjectIDType WritePage(PDFPage* inPage);
 		EStatusCodeAndObjectIDType WritePageAndRelease(PDFPage* inPage);
 
@@ -180,12 +180,12 @@ namespace PDFHummus
 		PDFHummus::EStatusCode EndTiledPatternAndRelease(PDFTiledPattern* inTiledPattern);
 
 
-		// Image XObject creating. 
+		// Image XObject creating.
 		// note that as oppose to other methods, create the image xobject also writes it, so there's no "WriteXXXXAndRelease" for image.
 		// So...release the object yourself [just delete it]
 
 		// JPEG - two variants
-		
+
 		// will return image xobject sized at 1X1
 		PDFImageXObject* CreateImageXObjectFromJPGFile(const std::string& inJPGFilePath);
 		PDFImageXObject* CreateImageXObjectFromJPGStream(IByteReaderWithPosition* inJPGStream);
@@ -217,7 +217,7 @@ namespace PDFHummus
 #endif
 
 		// PDF
-		// CreateFormXObjectsFromPDF is for using input PDF pages as objects in one page or more. you can used the returned IDs to place the 
+		// CreateFormXObjectsFromPDF is for using input PDF pages as objects in one page or more. you can used the returned IDs to place the
 		// created form xobjects (note that you can provide your own as the inPredefinedFormIds...just make sure the list is same size as pages list)
 		EStatusCodeAndObjectIDTypeList CreateFormXObjectsFromPDF(const std::string& inPDFFilePath,
 																 const PDFParsingOptions& inParsingOptions,
@@ -234,7 +234,7 @@ namespace PDFHummus
 																 const double* inTransformationMatrix = NULL,
 																 const ObjectIDTypeList& inCopyAdditionalObjects = ObjectIDTypeList(),
 																 const ObjectIDTypeList& inPredefinedFormIDs = ObjectIDTypeList());
-		
+
 		// CreateFormXObjectsFromPDF is an override to allow you to determine a custom crop for the page embed
 		EStatusCodeAndObjectIDTypeList CreateFormXObjectsFromPDF(const std::string& inPDFFilePath,
 																const PDFParsingOptions& inParsingOptions,
@@ -257,7 +257,7 @@ namespace PDFHummus
 															const PDFParsingOptions& inParsingOptions,
 															const PDFPageRange& inPageRange,
 															const ObjectIDTypeList& inCopyAdditionalObjects = ObjectIDTypeList());
-		
+
 		EStatusCodeAndObjectIDTypeList AppendPDFPagesFromPDF(IByteReaderWithPosition* inPDFStream,
 															const PDFParsingOptions& inParsingOptions,
 															const PDFPageRange& inPageRange,
@@ -283,7 +283,9 @@ namespace PDFHummus
 
 		// some public image info services, for users of hummus
 		DoubleAndDoublePair GetImageDimensions(const std::string& inImageFile,unsigned long inImageIndex = 0, const PDFParsingOptions& inOptions = PDFParsingOptions::DefaultPDFParsingOptions());
-		EHummusImageType GetImageType(const std::string& inImageFile,unsigned long inImageIndex);
+    DoubleAndDoublePair GetImageDimensions(IByteReaderWithPosition* inImageStream,unsigned long inImageIndex = 0, const PDFParsingOptions& inOptions = PDFParsingOptions::DefaultPDFParsingOptions());
+    EHummusImageType GetImageType(const std::string& inImageFile,unsigned long inImageIndex);
+    EHummusImageType GetImageType(IByteReaderWithPosition* inImageStream,unsigned long inImageIndex);
 		unsigned long GetImagePagesCount(const std::string& inImageFile, const PDFParsingOptions& inOptions = PDFParsingOptions::DefaultPDFParsingOptions());
 
 
@@ -299,7 +301,7 @@ namespace PDFHummus
 		void AddDocumentContextExtender(IDocumentContextExtender* inExtender);
 		void RemoveDocumentContextExtender(IDocumentContextExtender* inExtender);
 		void SetParserExtender(IPDFParserExtender* inParserExtender);
-        
+
         // Extensibility option. a method of adding direct objects to a resource dictionary of a form or page.
         // resource writing tasks are one time objects (deleted when done, owned by documentcontext) that
         // are called when a certain resoruce category for a certain form is written. each task
@@ -318,7 +320,7 @@ namespace PDFHummus
 		std::string AddExtendedResourceMapping(ResourcesDictionary* inResourceDictionary,
                                           const std::string& inResourceCategoryName,
                                           IResourceWritingTask* inWritingTask);
-        
+
         // Extensibility option. option of writing a single time task for when a particular form ends
         void RegisterFormEndWritingTask(PDFFormXObject* inFormXObject,IFormEndWritingTask* inWritingTask);
         // Extensibility option. option of writing a single time task for when a particular page ends
@@ -331,10 +333,10 @@ namespace PDFHummus
 		PDFHummus::EStatusCode ReadState(PDFParser* inStateReader,ObjectIDType inObjectID);
 
 		void Cleanup();
-        
+
         // modification scenario
         PDFHummus::EStatusCode SetupModifiedFile(PDFParser* inModifiedFileParser);
-		
+
 		// internal methods for copying context listeners handling
 		void RegisterCopyingContext(PDFDocumentCopyingContext* inCopyingContext);
 		void UnRegisterCopyingContext(PDFDocumentCopyingContext* inCopyingContext);
@@ -354,7 +356,7 @@ namespace PDFHummus
 #ifndef PDFHUMMUS_NO_TIFF
         TIFFImageHandler&  GetTIFFImageHandler();
 #endif
-		
+
 		// get annotations, for complex scenarios where writing a page can happen outside of document context
 		ObjectIDTypeSet& GetAnnotations();
 
@@ -386,7 +388,7 @@ namespace PDFHummus
 		PDFTiledPatternToITiledPatternEndWritingTaskListMap mTiledPatternEndTasks;
 	    StringAndULongPairToHummusImageInformationMap mImagesInformation;
 		EncryptionHelper mEncryptionHelper;
-		
+
 		void WriteHeaderComment(EPDFVersion inPDFVersion);
 		void Write4BinaryBytes();
 		PDFHummus::EStatusCode WriteCatalogObjectOfNewPDF();
@@ -424,7 +426,7 @@ namespace PDFHummus
 
 		void WritePageTreeState(ObjectsContext* inStateWriter,ObjectIDType inObjectID,PageTree* inPageTree);
 		void ReadPageTreeState(PDFParser* inStateReader,PDFDictionary* inPageTreeState,PageTree* inPageTree);
-        
+
         ObjectReference GetOriginalDocumentPageTreeRoot(PDFParser* inModifiedFileParser);
         bool DocumentHasNewPages();
         ObjectIDType WriteCombinedPageTree(PDFParser* inModifiedFileParser);

--- a/src/deps/PDFWriter/JPEGImageHandler.cpp
+++ b/src/deps/PDFWriter/JPEGImageHandler.cpp
@@ -16,7 +16,7 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 
-   
+
 */
 #include "JPEGImageHandler.h"
 #include "InputFile.h"
@@ -64,7 +64,7 @@ PDFImageXObject* JPEGImageHandler::CreateImageXObjectFromJPGFile(const std::stri
 {
 	PDFImageXObject* imageXObject = NULL;
 
-	do 
+	do
 	{
 		// retrieve image information
 		BoolAndJPEGImageInformation imageInformationResult = RetrieveImageInformation(inJPGFilePath);
@@ -79,7 +79,7 @@ PDFImageXObject* JPEGImageHandler::CreateImageXObjectFromJPGFile(const std::stri
 
 	} while(false);
 
-	return imageXObject;  	
+	return imageXObject;
 
 }
 
@@ -116,7 +116,7 @@ PDFImageXObject* JPEGImageHandler::CreateAndWriteImageXObjectFromJPGInformation(
 	return imageXObject;
 }
 
-																				
+
 PDFImageXObject* JPEGImageHandler::CreateAndWriteImageXObjectFromJPGInformation(IByteReaderWithPosition* inJPGImageStream,
 																				ObjectIDType inImageXObjectID,
 																				const JPEGImageInformation& inJPGImageInformation)
@@ -134,7 +134,7 @@ PDFImageXObject* JPEGImageHandler::CreateAndWriteImageXObjectFromJPGInformation(
 
 		mObjectsContext->StartNewIndirectObject(inImageXObjectID);
 		DictionaryContext* imageContext = mObjectsContext->StartDictionary();
-	
+
 		// type
 		imageContext->WriteKey(scType);
 		imageContext->WriteNameValue(scXObject);
@@ -167,7 +167,7 @@ PDFImageXObject* JPEGImageHandler::CreateAndWriteImageXObjectFromJPGInformation(
 				break;
 		case 4:
 				imageContext->WriteNameValue(scDeviceCMYK);
-				
+
 				// Decode array
 				imageContext->WriteKey(scDecode);
 				mObjectsContext->StartArray();
@@ -203,10 +203,10 @@ PDFImageXObject* JPEGImageHandler::CreateAndWriteImageXObjectFromJPGInformation(
 				status = PDFHummus::eFailure;
 				break;
 			}
-		}	
+		}
 		if(status != PDFHummus::eSuccess)
 			break;
-		
+
 
 		PDFStream* imageStream = mObjectsContext->StartUnfilteredPDFStream(imageContext);
 
@@ -218,17 +218,39 @@ PDFImageXObject* JPEGImageHandler::CreateAndWriteImageXObjectFromJPGInformation(
 			delete imageStream;
 			break;
 		}
-	
+
 		mObjectsContext->EndPDFStream(imageStream);
 		delete imageStream;
 
 		imageXObject = new PDFImageXObject(inImageXObjectID,1 == inJPGImageInformation.ColorComponentsCount ? KProcsetImageB:KProcsetImageC);
 	}while(false);
-	
+
 
 	return imageXObject;
 }
 
+BoolAndJPEGImageInformation JPEGImageHandler::RetrieveImageInformation(IByteReaderWithPosition* inJPGStream)
+{
+	BoolAndJPEGImageInformation imageInformationResult(false,mNullInformation);
+
+	do
+	{
+		JPEGImageParser jpgImageParser;
+		JPEGImageInformation imageInformation;
+
+		EStatusCode status = jpgImageParser.Parse(inJPGStream,imageInformation);
+		if(status != PDFHummus::eSuccess)
+		{
+			TRACE_LOG("JPEGImageHandler::JPEGImageHandler. Failed to parse JPG stream");
+			break;
+		}
+
+		imageInformationResult.first = true;
+		imageInformationResult.second = imageInformation;
+	} while(false);
+
+	return imageInformationResult;
+}
 
 BoolAndJPEGImageInformation JPEGImageHandler::RetrieveImageInformation(const std::string& inJPGFilePath)
 {
@@ -249,7 +271,7 @@ BoolAndJPEGImageInformation JPEGImageHandler::RetrieveImageInformation(const std
 
 			JPEGImageParser jpgImageParser;
 			JPEGImageInformation imageInformation;
-			
+
 			status = jpgImageParser.Parse(JPGFile.GetInputStream(),imageInformation);
 			if(status != PDFHummus::eSuccess)
 			{
@@ -294,7 +316,7 @@ PDFFormXObject* JPEGImageHandler::CreateFormXObjectFromJPGFile(const std::string
 	PDFImageXObject* imageXObject = NULL;
 	PDFFormXObject* imageFormXObject = NULL;
 
-	do 
+	do
 	{
 		if(!mObjectsContext)
 		{
@@ -330,7 +352,7 @@ PDFFormXObject* JPEGImageHandler::CreateFormXObjectFromJPGFile(const std::string
 	} while(false);
 
 	delete imageXObject;
-	return imageFormXObject;  	
+	return imageFormXObject;
 }
 
 PDFFormXObject* JPEGImageHandler::CreateImageFormXObjectFromImageXObject(PDFImageXObject* inImageXObject,ObjectIDType inFormXObjectID, const JPEGImageInformation& inJPGImageInformation)
@@ -361,7 +383,7 @@ PDFFormXObject* JPEGImageHandler::CreateImageFormXObjectFromImageXObject(PDFImag
 			delete formXObject;
 			formXObject = NULL;
 			break;
-		}	
+		}
 
 
 	}while(false);
@@ -479,7 +501,7 @@ PDFImageXObject* JPEGImageHandler::CreateImageXObjectFromJPGStream(IByteReaderWi
 {
 	PDFImageXObject* imageXObject = NULL;
 
-	do 
+	do
 	{
 		if(!mObjectsContext)
 		{
@@ -491,7 +513,7 @@ PDFImageXObject* JPEGImageHandler::CreateImageXObjectFromJPGStream(IByteReaderWi
 		JPEGImageInformation imageInformation;
 
 		LongFilePositionType recordedPosition = inJPGStream->GetCurrentPosition();
-		
+
 		EStatusCode status = jpgImageParser.Parse(inJPGStream,imageInformation);
 		if(status != PDFHummus::eSuccess)
 		{
@@ -506,7 +528,7 @@ PDFImageXObject* JPEGImageHandler::CreateImageXObjectFromJPGStream(IByteReaderWi
 
 	} while(false);
 
-	return imageXObject;  	
+	return imageXObject;
 
 }
 
@@ -526,7 +548,7 @@ PDFFormXObject* JPEGImageHandler::CreateFormXObjectFromJPGStream(IByteReaderWith
 	PDFFormXObject* imageFormXObject = NULL;
 	PDFImageXObject* imageXObject = NULL;
 
-	do 
+	do
 	{
 		if(!mObjectsContext)
 		{
@@ -538,7 +560,7 @@ PDFFormXObject* JPEGImageHandler::CreateFormXObjectFromJPGStream(IByteReaderWith
 		JPEGImageInformation imageInformation;
 
 		LongFilePositionType recordedPosition = inJPGStream->GetCurrentPosition();
-		
+
 		EStatusCode status = jpgImageParser.Parse(inJPGStream,imageInformation);
 		if(status != PDFHummus::eSuccess)
 		{
@@ -567,7 +589,7 @@ PDFFormXObject* JPEGImageHandler::CreateFormXObjectFromJPGStream(IByteReaderWith
 	} while(false);
 
 	delete imageXObject;
-	return imageFormXObject;  
+	return imageFormXObject;
 }
 
 int JPEGImageHandler::GetColorComponents(const JPEGImageInformation& inJPGImageInformation)

--- a/src/deps/PDFWriter/JPEGImageHandler.h
+++ b/src/deps/PDFWriter/JPEGImageHandler.h
@@ -16,7 +16,7 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 
-   
+
 */
 #pragma once
 
@@ -58,13 +58,14 @@ public:
 
 	// use this for retrieving image information for JPEG (useful for deciphering JPG dimensions tags)
 	BoolAndJPEGImageInformation RetrieveImageInformation(const std::string& inJPGFilePath);
+  BoolAndJPEGImageInformation RetrieveImageInformation(IByteReaderWithPosition* inJPGStream);
 
 	// DocumentContext::CreateImageXObjectFromJPGFile are equivelent
 	PDFImageXObject* CreateImageXObjectFromJPGFile(const std::string& inJPGFilePath);
 	PDFImageXObject* CreateImageXObjectFromJPGStream(IByteReaderWithPosition* inJPGStream);
 	PDFImageXObject* CreateImageXObjectFromJPGFile(const std::string& inJPGFilePath,ObjectIDType inImageXObjectID);
 	PDFImageXObject* CreateImageXObjectFromJPGStream(IByteReaderWithPosition* inJPGStream,ObjectIDType inImageXObjectID);
-	
+
 	// will return form XObject, which will include the xobject at it's size
 	PDFFormXObject* CreateFormXObjectFromJPGFile(const std::string& inJPGFilePath);
 	PDFFormXObject* CreateFormXObjectFromJPGStream(IByteReaderWithPosition* inJPGStream);

--- a/src/deps/PDFWriter/PDFWriter.cpp
+++ b/src/deps/PDFWriter/PDFWriter.cpp
@@ -16,7 +16,7 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 
-   
+
 */
 
 #include "PDFWriter.h"
@@ -74,7 +74,7 @@ EStatusCode PDFWriter::StartPDF(
 		return status;
 
 	mObjectsContext.SetOutputStream(mOutputFile.GetOutputStream());
-	mDocumentContext.SetOutputFileInformation(&mOutputFile);    
+	mDocumentContext.SetOutputFileInformation(&mOutputFile);
 
 	if (inPDFCreationSettings.DocumentEncryptionOptions.ShouldEncrypt) {
 		mDocumentContext.SetupEncryption(inPDFCreationSettings.DocumentEncryptionOptions, thisOrDefaultVersion(inPDFVersion));
@@ -85,19 +85,19 @@ EStatusCode PDFWriter::StartPDF(
 	}
 
 	mIsModified = false;
-	
+
 	return mDocumentContext.WriteHeader(thisOrDefaultVersion(inPDFVersion));
 }
 
 EStatusCode PDFWriter::EndPDF()
 {
-    
+
 	EStatusCode status;
 	do
 	{
         if(mIsModified)
             status = mDocumentContext.FinalizeModifiedPDF(&mModifiedFileParser,mModifiedFileVersion);
-        else    
+        else
             status = mDocumentContext.FinalizeNewPDF();
 		if(status != eSuccess)
 		{
@@ -109,13 +109,13 @@ EStatusCode PDFWriter::EndPDF()
         {
             TRACE_LOG("PDFWriter::EndPDF, Could not close output file");
             break;
-    
+
         }
         mModifiedFileParser.ResetParser();
         status = mModifiedFile.CloseFile();
 	}
 	while(false);
-    
+
     if(status != eSuccess)
     {
         mOutputFile.CloseFile();
@@ -233,18 +233,18 @@ EStatusCode PDFWriter::EndFormXObjectAndRelease(PDFFormXObject* inFormXObject)
 
 PDFImageXObject* PDFWriter::CreateImageXObjectFromJPGFile(const std::string& inJPGFilePath)
 {
-	return mDocumentContext.CreateImageXObjectFromJPGFile(inJPGFilePath); 
+	return mDocumentContext.CreateImageXObjectFromJPGFile(inJPGFilePath);
 }
 
 PDFFormXObject* PDFWriter::CreateFormXObjectFromJPGFile(const std::string& inJPGFilePath)
 {
-	return mDocumentContext.CreateFormXObjectFromJPGFile(inJPGFilePath); 
+	return mDocumentContext.CreateFormXObjectFromJPGFile(inJPGFilePath);
 }
 
 #ifndef PDFHUMMUS_NO_TIFF
 PDFFormXObject* PDFWriter::CreateFormXObjectFromTIFFFile(const std::string& inTIFFFilePath,const TIFFUsageParameters& inTIFFUsageParameters)
 {
-	return mDocumentContext.CreateFormXObjectFromTIFFFile(inTIFFFilePath,inTIFFUsageParameters); 
+	return mDocumentContext.CreateFormXObjectFromTIFFFile(inTIFFFilePath,inTIFFUsageParameters);
 }
 
 PDFFormXObject* PDFWriter::CreateFormXObjectFromTIFFFile(const std::string& inTIFFFilePath,ObjectIDType inFormXObjectID, const TIFFUsageParameters& inTIFFUsageParameters)
@@ -294,12 +294,12 @@ PDFFormXObject* PDFWriter::CreateFormXObjectFromPNGStream(IByteReaderWithPositio
 
 PDFImageXObject* PDFWriter::CreateImageXObjectFromJPGFile(const std::string& inJPGFilePath,ObjectIDType inImageXObjectID)
 {
-	return mDocumentContext.CreateImageXObjectFromJPGFile(inJPGFilePath,inImageXObjectID); 
+	return mDocumentContext.CreateImageXObjectFromJPGFile(inJPGFilePath,inImageXObjectID);
 }
 
 PDFFormXObject* PDFWriter::CreateFormXObjectFromJPGFile(const std::string& inJPGFilePath,ObjectIDType inImageXObjectID)
 {
-	return mDocumentContext.CreateFormXObjectFromJPGFile(inJPGFilePath,inImageXObjectID); 
+	return mDocumentContext.CreateFormXObjectFromJPGFile(inJPGFilePath,inImageXObjectID);
 }
 
 
@@ -393,7 +393,7 @@ EStatusCode PDFWriter::Shutdown(const std::string& inStateFilePath)
             pdfWriterDictionary->WriteKey("mModifiedFileVersion");
             pdfWriterDictionary->WriteIntegerValue(mModifiedFileVersion);
         }
-        
+
 		writer.GetObjectsWriter()->EndDictionary(pdfWriterDictionary);
 		writer.GetObjectsWriter()->EndIndirectObject();
 
@@ -431,7 +431,7 @@ EStatusCode PDFWriter::ContinuePDF(const std::string& inOutputFilePath,
                                    const std::string& inOptionalModifiedFile,
 								   const LogConfiguration& inLogConfiguration)
 {
-	
+
 
 	SetupLog(inLogConfiguration);
 	EStatusCode status = mOutputFile.OpenFile(inOutputFilePath,true);
@@ -444,12 +444,12 @@ EStatusCode PDFWriter::ContinuePDF(const std::string& inOutputFilePath,
         status = mModifiedFile.OpenFile(inOptionalModifiedFile);
         if(status != eSuccess)
             return status;
-        
+
         status = mModifiedFileParser.StartPDFParsing(mModifiedFile.GetInputStream());
         if(status != eSuccess)
             return status;
     }
-    
+
 	mObjectsContext.SetOutputStream(mOutputFile.GetOutputStream());
 	mDocumentContext.SetOutputFileInformation(&mOutputFile);
 
@@ -477,7 +477,7 @@ EStatusCode PDFWriter::SetupState(const std::string& inStateFilePath)
 
         PDFObjectCastPtr<PDFBoolean> isModifiedObject(pdfWriterDictionary->QueryDirectObject("mIsModified"));
         mIsModified = isModifiedObject->GetValue();
-        
+
         if(mIsModified)
         {
             PDFObjectCastPtr<PDFInteger> isModifiedFileVersionObject(pdfWriterDictionary->QueryDirectObject("mModifiedFileVersion"));
@@ -508,11 +508,11 @@ EStatusCode PDFWriter::ContinuePDFForStream(IByteWriterWithPosition* inOutputStr
 			 								const LogConfiguration& inLogConfiguration)
 {
 	SetupLog(inLogConfiguration);
-    
+
     if(inModifiedSourceStream)
         if(mModifiedFileParser.StartPDFParsing(inModifiedSourceStream) != eSuccess)
             return eFailure;
- 
+
 	mObjectsContext.SetOutputStream(inOutputStream);
 
 	return SetupState(inStateFilePath);
@@ -559,16 +559,16 @@ EStatusCode PDFWriter::StartPDFForStream(IByteWriterWithPosition* inOutputStream
 
 	mObjectsContext.SetOutputStream(inOutputStream);
     mIsModified = false;
-	
+
 	return mDocumentContext.WriteHeader(thisOrDefaultVersion(inPDFVersion));
 }
 EStatusCode PDFWriter::EndPDFForStream()
 {
     EStatusCode status;
-    
+
     if(mIsModified)
         status = mDocumentContext.FinalizeModifiedPDF(&mModifiedFileParser,mModifiedFileVersion);
-    else    
+    else
         status = mDocumentContext.FinalizeNewPDF();
     mModifiedFileParser.ResetParser();
 	Cleanup();
@@ -635,7 +635,7 @@ EStatusCode PDFWriter::MergePDFPagesToPage(	PDFPage* inPage,
 
 PDFDocumentCopyingContext* PDFWriter::CreatePDFCopyingContext(IByteReaderWithPosition* inPDFStream, const PDFParsingOptions& inOptions)
 {
-	return mDocumentContext.CreatePDFCopyingContext(inPDFStream,inOptions);	
+	return mDocumentContext.CreatePDFCopyingContext(inPDFStream,inOptions);
 }
 
 EStatusCode PDFWriter::ModifyPDF(const std::string& inModifiedFile,
@@ -645,11 +645,11 @@ EStatusCode PDFWriter::ModifyPDF(const std::string& inModifiedFile,
                                             const PDFCreationSettings& inPDFCreationSettings)
 {
     EStatusCode status = eSuccess;
-    
+
     SetupLog(inLogConfiguration);
 	SetupCreationSettings(inPDFCreationSettings);
-	
-    do 
+
+    do
     {
         // either append to original file, or create a new copy and "modify" it. depending on users choice
         if(inOptionalAlternativeOutputFile.size() == 0 || (inOptionalAlternativeOutputFile == inModifiedFile))
@@ -664,13 +664,13 @@ EStatusCode PDFWriter::ModifyPDF(const std::string& inModifiedFile,
             status = mOutputFile.OpenFile(inOptionalAlternativeOutputFile);
             if(status != eSuccess)
                break;
-            
+
             // copy original to new output file
             InputFile modifiedFileInput;
             status = modifiedFileInput.OpenFile(inModifiedFile);
             if(status != eSuccess)
                 break;
-            
+
             OutputStreamTraits traits(mOutputFile.GetOutputStream());
             status = traits.CopyToOutputStream(modifiedFileInput.GetInputStream());
             if(status != eSuccess)
@@ -680,15 +680,15 @@ EStatusCode PDFWriter::ModifyPDF(const std::string& inModifiedFile,
 			mObjectsContext.SetOutputStream(mOutputFile.GetOutputStream());
 			mObjectsContext.WriteTokenSeparator(eTokenSeparatorEndLine);
         }
-        
+
         mDocumentContext.SetOutputFileInformation(&mOutputFile);
-        
-        // do setup for modification 
+
+        // do setup for modification
         mIsModified = true;
         status = SetupStateFromModifiedFile(inModifiedFile, thisOrDefaultVersion(inPDFVersion), inPDFCreationSettings);
-    } 
+    }
     while (false);
-           
+
     return status;
 }
 
@@ -699,10 +699,10 @@ EStatusCode PDFWriter::ModifyPDFForStream(
                                       EPDFVersion inPDFVersion,
                                       const LogConfiguration& inLogConfiguration,
                                       const PDFCreationSettings& inPDFCreationSettings)
-{    
+{
     SetupLog(inLogConfiguration);
 	SetupCreationSettings(inPDFCreationSettings);
-    
+
     if(!inAppendOnly)
     {
         // copy original to new output stream
@@ -712,11 +712,11 @@ EStatusCode PDFWriter::ModifyPDFForStream(
             return status;
         inModifiedSourceStream->SetPosition(0);
     }
-	
+
     mObjectsContext.SetOutputStream(inModifiedDestinationStream);
-        
+
     mIsModified = true;
-        
+
     return SetupStateFromModifiedStream(inModifiedSourceStream, thisOrDefaultVersion(inPDFVersion), inPDFCreationSettings);
 }
 
@@ -726,7 +726,7 @@ EStatusCode PDFWriter::SetupStateFromModifiedStream(IByteReaderWithPosition* inM
 {
     EStatusCode status;
 	PDFParsingOptions parsingOptions;
-    
+
 	// this bit here is actually interesting. in order to modify an already encrypted document
 	// and add more content to it, i just need the user password. not the owner one.
 	// in fact, passing the owner password here will create the wrong encryption key.
@@ -734,18 +734,18 @@ EStatusCode PDFWriter::SetupStateFromModifiedStream(IByteReaderWithPosition* inM
 	if (inPDFCreationSettings.DocumentEncryptionOptions.ShouldEncrypt)
 		parsingOptions.Password = inPDFCreationSettings.DocumentEncryptionOptions.UserPassword;
 
-    do 
+    do
     {
         status = mModifiedFileParser.StartPDFParsing(inModifiedSourceStream, parsingOptions);
         if(status != eSuccess)
-            break;    
-        
+            break;
+
         mObjectsContext.SetupModifiedFile(&mModifiedFileParser);
-        
+
         status = mDocumentContext.SetupModifiedFile(&mModifiedFileParser);
         if(status != eSuccess)
             break;
-        
+
 		if (mModifiedFileParser.IsEncrypted() && mModifiedFileParser.IsEncryptionSupported()) {
 			mDocumentContext.SetupEncryption(&mModifiedFileParser);
 			if (!mDocumentContext.SupportsEncryption()) {
@@ -755,26 +755,26 @@ EStatusCode PDFWriter::SetupStateFromModifiedStream(IByteReaderWithPosition* inM
 		}
 
         mModifiedFileVersion = thisOrDefaultVersion(inPDFVersion);
-    } 
+    }
     while (false);
-    
+
     return status;
 }
 
 EStatusCode PDFWriter::SetupStateFromModifiedFile(const std::string& inModifiedFile,EPDFVersion inPDFVersion, const PDFCreationSettings& inPDFCreationSettings)
 {
     EStatusCode status;
-    
+
     do
     {
         status = mModifiedFile.OpenFile(inModifiedFile);
         if(status != eSuccess)
             break;
-        
+
         status = SetupStateFromModifiedStream(mModifiedFile.GetInputStream(), thisOrDefaultVersion(inPDFVersion), inPDFCreationSettings);
     }
     while(false);
-    
+
     return status;
 }
 
@@ -790,12 +790,17 @@ InputFile& PDFWriter::GetModifiedInputFile()
 
 PDFDocumentCopyingContext* PDFWriter::CreatePDFCopyingContextForModifiedFile()
 {
-	return mDocumentContext.CreatePDFCopyingContext(&mModifiedFileParser);    
+	return mDocumentContext.CreatePDFCopyingContext(&mModifiedFileParser);
 }
 
 DoubleAndDoublePair PDFWriter::GetImageDimensions(const std::string& inImageFile,unsigned long inImageIndex, const PDFParsingOptions& inParsingOptions)
 {
 	return mDocumentContext.GetImageDimensions(inImageFile,inImageIndex,inParsingOptions);
+}
+
+DoubleAndDoublePair PDFWriter::GetImageDimensions(IByteReaderWithPosition* inImageStream,unsigned long inImageIndex, const PDFParsingOptions& inParsingOptions)
+{
+	return mDocumentContext.GetImageDimensions(inImageStream,inImageIndex,inParsingOptions);
 }
 
 PDFHummus::EHummusImageType PDFWriter::GetImageType(const std::string& inImageFile,unsigned long inImageIndex)
@@ -815,7 +820,7 @@ PDFHummus::EStatusCode PDFWriter::RecryptPDF(
 	const LogConfiguration& inLogConfiguration,
 	const PDFCreationSettings& inPDFCreationSettings,
 	EPDFVersion inOveridePDFVersion) {
-	
+
 	InputFile originalPDF;
 	OutputFile newPDF;
 

--- a/src/deps/PDFWriter/PDFWriter.h
+++ b/src/deps/PDFWriter/PDFWriter.h
@@ -16,7 +16,7 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 
-   
+
 */
 #pragma once
 /*
@@ -60,8 +60,8 @@ struct PDFCreationSettings
 	bool EmbedFonts;
 	EncryptionOptions DocumentEncryptionOptions;
 
-	PDFCreationSettings(bool inCompressStreams, bool inEmbedFonts,EncryptionOptions inDocumentEncryptionOptions = EncryptionOptions::DefaultEncryptionOptions()):DocumentEncryptionOptions(inDocumentEncryptionOptions){ 
-		CompressStreams = inCompressStreams; 
+	PDFCreationSettings(bool inCompressStreams, bool inEmbedFonts,EncryptionOptions inDocumentEncryptionOptions = EncryptionOptions::DefaultEncryptionOptions()):DocumentEncryptionOptions(inDocumentEncryptionOptions){
+		CompressStreams = inCompressStreams;
 		EmbedFonts = inEmbedFonts;
 	}
 
@@ -98,22 +98,22 @@ public:
 	// in case of internal or external error, call this function to cleanup, in order to allow reuse of the PDFWriter class
 	void Reset();
 
-    
+
     // modify PDF (use EndPDF to finish)
     PDFHummus::EStatusCode ModifyPDF(const std::string& inModifiedFile,
                                      EPDFVersion inPDFVersion,
                                      const std::string& inOptionalAlternativeOutputFile,
                                      const LogConfiguration& inLogConfiguration = LogConfiguration::DefaultLogConfiguration(),
-                                     const PDFCreationSettings& inPDFCreationSettings = PDFCreationSettings(true,true));                                 
+                                     const PDFCreationSettings& inPDFCreationSettings = PDFCreationSettings(true,true));
     PDFHummus::EStatusCode ModifyPDFForStream(
                                     IByteReaderWithPosition* inModifiedSourceStream,
                                     IByteWriterWithPosition* inModifiedDestinationStream,
                                     bool inAppendOnly,
                                     EPDFVersion inPDFVersion,
                                     const LogConfiguration& inLogConfiguration = LogConfiguration::DefaultLogConfiguration(),
-                                    const PDFCreationSettings& inPDFCreationSettings = PDFCreationSettings(true,true)                                 
+                                    const PDFCreationSettings& inPDFCreationSettings = PDFCreationSettings(true,true)
                                     );
-    
+
 	// Ending and Restarting writing session (optional input file is for modification scenarios)
 	PDFHummus::EStatusCode Shutdown(const std::string& inStateFilePath);
 	PDFHummus::EStatusCode ContinuePDF(const std::string& inOutputFilePath,
@@ -147,10 +147,10 @@ public:
     PDFHummus::EStatusCode EndFormXObject(PDFFormXObject* inFormXObject);
 	PDFHummus::EStatusCode EndFormXObjectAndRelease(PDFFormXObject* inFormXObject);
 
-	// Image XObject creating [for TIFF nad JPG files]. 
+	// Image XObject creating [for TIFF nad JPG files].
 	// note that as oppose to other methods, create the image xobject also writes it, so there's no "WriteXXXXAndRelease" for image.
 	// So...release the object yourself [just delete it]
-	
+
 	// jpeg - two variants
 	// will return image xobject sized at 1X1
 	PDFImageXObject* CreateImageXObjectFromJPGFile(const std::string& inJPGFilePath);
@@ -168,7 +168,7 @@ public:
 	PDFFormXObject* CreateFormXObjectFromJPGStream(IByteReaderWithPosition* inJPGStream);
 	PDFFormXObject* CreateFormXObjectFromJPGFile(const std::string& inJPGFilePath,ObjectIDType inFormXObjectID);
 	PDFFormXObject* CreateFormXObjectFromJPGStream(IByteReaderWithPosition* inJPGStream,ObjectIDType inFormXObjectID);
-	
+
 	// tiff
 #ifndef PDFHUMMUS_NO_TIFF
 	PDFFormXObject* CreateFormXObjectFromTIFFFile(	const std::string& inTIFFFilePath,
@@ -191,9 +191,9 @@ public:
 	PDFFormXObject* CreateFormXObjectFromPNGStream(IByteReaderWithPosition* inPNGStream, ObjectIDType inFormXObjectID);
 #endif
 
-	// PDF 
+	// PDF
 
-	// CreateFormXObjectsFromPDF is for using input PDF pages as objects in one page or more. you can used the returned IDs to place the 
+	// CreateFormXObjectsFromPDF is for using input PDF pages as objects in one page or more. you can used the returned IDs to place the
 	// created form xobjects
 	EStatusCodeAndObjectIDTypeList CreateFormXObjectsFromPDF(const std::string& inPDFFilePath,
 															 const PDFPageRange& inPageRange,
@@ -208,7 +208,7 @@ public:
 															 const double* inTransformationMatrix = NULL,
 															 const ObjectIDTypeList& inCopyAdditionalObjects = ObjectIDTypeList(),
 															 const PDFParsingOptions& inParsingOptions = PDFParsingOptions::DefaultPDFParsingOptions());
-	
+
 	// CreateFormXObjectsFromPDF is an override to allow you to determine a custom crop for the page embed
 	EStatusCodeAndObjectIDTypeList CreateFormXObjectsFromPDF(const std::string& inPDFFilePath,
 															 const PDFPageRange& inPageRange,
@@ -229,7 +229,7 @@ public:
 														const PDFPageRange& inPageRange,
 														const ObjectIDTypeList& inCopyAdditionalObjects = ObjectIDTypeList(),
 														const PDFParsingOptions& inParsingOptions = PDFParsingOptions::DefaultPDFParsingOptions());
-	
+
 	EStatusCodeAndObjectIDTypeList AppendPDFPagesFromPDF(IByteReaderWithPosition* inPDFStream,
 														const PDFPageRange& inPageRange,
 														const ObjectIDTypeList& inCopyAdditionalObjects = ObjectIDTypeList(),
@@ -252,18 +252,19 @@ public:
 
 	// Copying context, allowing for a continous flow of copying from multiple sources PDFs (create one per source) to target PDF
 	PDFDocumentCopyingContext* CreatePDFCopyingContext(
-		const std::string& inPDFFilePath, 
+		const std::string& inPDFFilePath,
 		const PDFParsingOptions& inOptions = PDFParsingOptions::DefaultPDFParsingOptions());
 	PDFDocumentCopyingContext* CreatePDFCopyingContext(
-		IByteReaderWithPosition* inPDFStream, 
+		IByteReaderWithPosition* inPDFStream,
 		const PDFParsingOptions& inOptions = PDFParsingOptions::DefaultPDFParsingOptions());
-    
+
     // for modified file path, create a copying context for the modified file
     PDFDocumentCopyingContext* CreatePDFCopyingContextForModifiedFile();
 
 	// some public image info services, for users of hummus
 	DoubleAndDoublePair GetImageDimensions(const std::string& inImageFile,unsigned long inImageIndex = 0, const PDFParsingOptions& inParsingOptions = PDFParsingOptions::DefaultPDFParsingOptions());
-	EHummusImageType GetImageType(const std::string& inImageFile,unsigned long inImageIndex);
+  DoubleAndDoublePair GetImageDimensions(IByteReaderWithPosition* inImageStream,unsigned long inImageIndex = 0, const PDFParsingOptions& inParsingOptions = PDFParsingOptions::DefaultPDFParsingOptions());
+  EHummusImageType GetImageType(const std::string& inImageFile,unsigned long inImageIndex);
 	unsigned long GetImagePagesCount(const std::string& inImageFile, const PDFParsingOptions& inOptions = PDFParsingOptions::DefaultPDFParsingOptions());
 
 
@@ -281,7 +282,7 @@ public:
 	PDFHummus::DocumentContext& GetDocumentContext();
 	ObjectsContext& GetObjectsContext();
 	OutputFile& GetOutputFile();
-    
+
     // Extensibiility, for modified files workflow
     PDFParser& GetModifiedFileParser();
     InputFile& GetModifiedInputFile();
@@ -312,7 +313,7 @@ private:
 
 	// for output file workflow, this will be the valid output [stream workflow does not have a file]
 	OutputFile mOutputFile;
-    
+
     // for modified workflow, the next two will hold the input file data
     InputFile mModifiedFile;
     PDFParser mModifiedFileParser;


### PR DESCRIPTION
PR to solve #354 

Adds implementation to accept a stream as getImageDimensions parameter and includes required internal methods to acomplish it.

JPEGImageHandler::RetrieveImageInformation using stream as parameter
DocumentContext::GetImageType using stream as parameter