### PR TITLE
bug: 32 bit and new tiff dont get along on some images. this is an attempt to fix this

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,9 +35,12 @@ jobs:
       matrix:
         os: [ubuntu-20.04, macos-14, windows-2019]
         node: [13.14.0, 14.0.0, 15.7.0, 16.13.1, 17.6.0, 18.8.0, 19.0.0, 20.0.0]
-        architecture: [x64, arm64]
+        architecture: [x64, ia32, arm64]
         include:
           - python_version: "3.10"
+          - architecture: ia32
+            architecture_node: x86
+            target_architecture: ia32
           - architecture: x64
             architecture_node: x64
             target_architecture: x64
@@ -51,6 +54,10 @@ jobs:
             architecture: arm64
           - os: windows-2019
             architecture: arm64
+          - os: macos-14
+            architecture: ia32
+          - os: ubuntu-20.04
+            architecture: ia32
           - os: macos-14
             node: 13.14.0
             architecture: arm64

--- a/src/deps/LibTiff/binding.gyp
+++ b/src/deps/LibTiff/binding.gyp
@@ -30,6 +30,11 @@
                     "defines": [
                         'HAVE_UNISTD_H=1'
                     ]
+                }],
+                ['target_arch == "ia32"', {
+                    "defines": [
+                        'SIZEOF_SIZE_T=4'
+                    ]
                 }]
             ],     
             'include_dirs': [

--- a/src/deps/LibTiff/tif_config.h
+++ b/src/deps/LibTiff/tif_config.h
@@ -45,8 +45,10 @@
 /* Define to the home page for this package. */
 #define PACKAGE_URL ""
 
-/* Size of size_t */
+/* Size of size_t, allowing external override */
+#ifndef SIZEOF_SIZE_T
 #define SIZEOF_SIZE_T 8
+#endif
 
 
 /** Maximum number of TIFF IFDs that libtiff can iterate through in a file. */


### PR DESCRIPTION
lets try to put back win32 (in case it's interesting after all), and correct the new lib setup to allow those few tiffs that fail testing.